### PR TITLE
javax @Generated replaced with custom @Generated annotation

### DIFF
--- a/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/CommonClassNames.java
+++ b/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/CommonClassNames.java
@@ -34,4 +34,6 @@ public class CommonClassNames {
     public static final ClassName graphInterceptor = ClassName.get("ru.tinkoff.kora.application.graph", "GraphInterceptor");
     public static final ClassName promisedProxy = ClassName.get("ru.tinkoff.kora.common", "PromisedProxy");
     public static final ClassName refreshListener = ClassName.get("ru.tinkoff.kora.application.graph", "RefreshListener");
+
+    public static final ClassName koraGenerated = ClassName.get("ru.tinkoff.kora.common.annotation", "Generated");
 }

--- a/aop/aop-annotation-processor/src/main/java/ru/tinkoff/kora/aop/annotation/processor/AopProcessor.java
+++ b/aop/aop-annotation-processor/src/main/java/ru/tinkoff/kora/aop/annotation/processor/AopProcessor.java
@@ -8,8 +8,8 @@ import ru.tinkoff.kora.annotation.processor.common.ProcessingErrorException;
 import ru.tinkoff.kora.annotation.processor.common.TagUtils;
 import ru.tinkoff.kora.common.Component;
 import ru.tinkoff.kora.common.Tag;
+import ru.tinkoff.kora.common.annotation.Generated;
 
-import javax.annotation.processing.Generated;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeKind;

--- a/aop/aop-symbol-processor/src/main/kotlin/ru/tinkoff/kora/aop/symbol/processor/AopProcessor.kt
+++ b/aop/aop-symbol-processor/src/main/kotlin/ru/tinkoff/kora/aop/symbol/processor/AopProcessor.kt
@@ -10,12 +10,12 @@ import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.toTypeVariableName
 import ru.tinkoff.kora.common.Component
+import ru.tinkoff.kora.common.annotation.Generated
 import ru.tinkoff.kora.ksp.common.KoraSymbolProcessingEnv
 import ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException
 import ru.tinkoff.kora.ksp.common.findMethods
 import ru.tinkoff.kora.ksp.common.makeTagAnnotationSpec
 import ru.tinkoff.kora.ksp.common.parseTags
-import javax.annotation.processing.Generated
 
 @KspExperimental
 class AopProcessor(private val aspects: List<KoraAspect>, private val resolver: Resolver) {

--- a/cache/cache-annotation-processor/src/main/java/ru/tinkoff/kora/cache/annotation/processor/CacheKeyAnnotationProcessor.java
+++ b/cache/cache-annotation-processor/src/main/java/ru/tinkoff/kora/cache/annotation/processor/CacheKeyAnnotationProcessor.java
@@ -3,9 +3,9 @@ package ru.tinkoff.kora.cache.annotation.processor;
 import ru.tinkoff.kora.annotation.processor.common.AbstractKoraProcessor;
 import ru.tinkoff.kora.annotation.processor.common.MethodUtils;
 import ru.tinkoff.kora.cache.annotation.*;
+import ru.tinkoff.kora.common.annotation.Generated;
 
 import javax.annotation.processing.Filer;
-import javax.annotation.processing.Generated;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.Element;
@@ -114,7 +114,7 @@ public class CacheKeyAnnotationProcessor extends AbstractKoraProcessor {
                     import java.util.Arrays;
                     import java.lang.Object;
                     import ru.tinkoff.kora.cache.CacheKey;
-                    import javax.annotation.processing.Generated;
+                    import ru.tinkoff.kora.common.annotation.Generated;
                                         
                     @%s("%s")
                     public record %s(%s) implements CacheKey {

--- a/cache/cache-symbol-processor/src/main/kotlin/ru/tinkoff/kora/cache/symbol/processor/CacheKeySymbolProcessor.kt
+++ b/cache/cache-symbol-processor/src/main/kotlin/ru/tinkoff/kora/cache/symbol/processor/CacheKeySymbolProcessor.kt
@@ -11,6 +11,7 @@ import com.squareup.kotlinpoet.ksp.writeTo
 import ru.tinkoff.kora.cache.CacheKey
 import ru.tinkoff.kora.cache.annotation.*
 import ru.tinkoff.kora.cache.symbol.processor.MethodUtils.Companion.getParameters
+import ru.tinkoff.kora.common.annotation.Generated
 import ru.tinkoff.kora.ksp.common.BaseSymbolProcessor
 import ru.tinkoff.kora.ksp.common.FunctionUtils.isFlow
 import ru.tinkoff.kora.ksp.common.FunctionUtils.isFlux
@@ -22,7 +23,6 @@ import ru.tinkoff.kora.ksp.common.exception.ProcessingError
 import ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException
 import ru.tinkoff.kora.ksp.common.visitFunction
 import java.io.IOException
-import javax.annotation.processing.Generated
 
 @KspExperimental
 class CacheKeySymbolProcessor(

--- a/common/src/main/java/ru/tinkoff/kora/common/annotation/Generated.java
+++ b/common/src/main/java/ru/tinkoff/kora/common/annotation/Generated.java
@@ -1,0 +1,23 @@
+package ru.tinkoff.kora.common.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The Generated annotation is used to mark source code that has been generated.
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface Generated {
+
+    /**
+     * The value element must have the name of the code generator.
+     * The recommended convention is to use the fully qualified name of the code generator. For example: com.acme.generator.CodeGen.
+     *
+     * @return The name of the code generator
+     */
+    String[] value();
+}

--- a/config/config-annotation-processor/src/main/java/ru/tinkoff/kora/config/annotation/processor/ConfigParserGenerator.java
+++ b/config/config-annotation-processor/src/main/java/ru/tinkoff/kora/config/annotation/processor/ConfigParserGenerator.java
@@ -5,13 +5,13 @@ import com.typesafe.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ru.tinkoff.kora.annotation.processor.common.CommonUtils;
+import ru.tinkoff.kora.common.annotation.Generated;
 import ru.tinkoff.kora.config.annotation.processor.exception.NewRoundWantedException;
 import ru.tinkoff.kora.config.common.extractor.ConfigValueExtractor;
 import ru.tinkoff.kora.config.common.extractor.ConfigValueUtils;
 import ru.tinkoff.kora.config.common.extractor.ObjectConfigValueExtractor;
 
 import javax.annotation.Nullable;
-import javax.annotation.processing.Generated;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.ExecutableElement;

--- a/config/config-annotation-processor/src/main/java/ru/tinkoff/kora/config/annotation/processor/ConfigRootModuleGenerator.java
+++ b/config/config-annotation-processor/src/main/java/ru/tinkoff/kora/config/annotation/processor/ConfigRootModuleGenerator.java
@@ -5,11 +5,11 @@ import com.typesafe.config.Config;
 import ru.tinkoff.kora.annotation.processor.common.CommonUtils;
 import ru.tinkoff.kora.common.Module;
 import ru.tinkoff.kora.common.Tag;
+import ru.tinkoff.kora.common.annotation.Generated;
 import ru.tinkoff.kora.config.annotation.processor.exception.NewRoundWantedException;
 import ru.tinkoff.kora.config.common.ConfigRoot;
 import ru.tinkoff.kora.config.common.extractor.ConfigValueExtractor;
 
-import javax.annotation.processing.Generated;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.*;

--- a/config/config-annotation-processor/src/main/java/ru/tinkoff/kora/config/annotation/processor/processor/ConfigSourceAnnotationProcessor.java
+++ b/config/config-annotation-processor/src/main/java/ru/tinkoff/kora/config/annotation/processor/processor/ConfigSourceAnnotationProcessor.java
@@ -5,10 +5,10 @@ import com.typesafe.config.Config;
 import ru.tinkoff.kora.annotation.processor.common.AbstractKoraProcessor;
 import ru.tinkoff.kora.annotation.processor.common.CommonUtils;
 import ru.tinkoff.kora.common.Module;
+import ru.tinkoff.kora.common.annotation.Generated;
 import ru.tinkoff.kora.config.common.ConfigSource;
 import ru.tinkoff.kora.config.common.extractor.ConfigValueExtractor;
 
-import javax.annotation.processing.Generated;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;

--- a/config/config-symbol-processor/src/main/kotlin/ru/tinkoff/kora/config/ksp/ConfigParserGenerator.kt
+++ b/config/config-symbol-processor/src/main/kotlin/ru/tinkoff/kora/config/ksp/ConfigParserGenerator.kt
@@ -16,6 +16,7 @@ import com.typesafe.config.ConfigList
 import com.typesafe.config.ConfigObject
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import ru.tinkoff.kora.common.annotation.Generated
 import ru.tinkoff.kora.config.common.extractor.ConfigValueExtractor
 import ru.tinkoff.kora.config.common.extractor.ConfigValueUtils
 import ru.tinkoff.kora.config.common.extractor.ObjectConfigValueExtractor
@@ -25,7 +26,6 @@ import ru.tinkoff.kora.ksp.common.getOuterClassesAsPrefix
 import java.time.Duration
 import java.time.Period
 import java.time.temporal.TemporalAmount
-import javax.annotation.processing.Generated
 
 class ConfigParserGenerator(
     private val resolver: Resolver

--- a/config/config-symbol-processor/src/main/kotlin/ru/tinkoff/kora/config/ksp/ConfigRootModuleGenerator.kt
+++ b/config/config-symbol-processor/src/main/kotlin/ru/tinkoff/kora/config/ksp/ConfigRootModuleGenerator.kt
@@ -12,11 +12,11 @@ import com.squareup.kotlinpoet.ksp.toTypeName
 import com.typesafe.config.Config
 import ru.tinkoff.kora.common.Module
 import ru.tinkoff.kora.common.Tag
+import ru.tinkoff.kora.common.annotation.Generated
 import ru.tinkoff.kora.config.common.ConfigRoot
 import ru.tinkoff.kora.config.common.extractor.ConfigValueExtractor
 import ru.tinkoff.kora.config.ksp.exception.NewRoundWantedException
 import ru.tinkoff.kora.ksp.common.parseTagValue
-import javax.annotation.processing.Generated
 
 @KspExperimental
 class ConfigRootModuleGenerator(

--- a/config/config-symbol-processor/src/main/kotlin/ru/tinkoff/kora/config/ksp/processor/ConfigSourceSymbolProcessor.kt
+++ b/config/config-symbol-processor/src/main/kotlin/ru/tinkoff/kora/config/ksp/processor/ConfigSourceSymbolProcessor.kt
@@ -6,7 +6,6 @@ import com.google.devtools.ksp.processing.*
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
-import com.google.devtools.ksp.validate
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
@@ -14,12 +13,12 @@ import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.writeTo
 import com.typesafe.config.Config
 import ru.tinkoff.kora.common.Module
+import ru.tinkoff.kora.common.annotation.Generated
 import ru.tinkoff.kora.config.common.ConfigSource
 import ru.tinkoff.kora.config.common.extractor.ConfigValueExtractor
 import ru.tinkoff.kora.ksp.common.BaseSymbolProcessor
 import ru.tinkoff.kora.ksp.common.visitClass
 import java.io.IOException
-import javax.annotation.processing.Generated
 
 class ConfigSourceSymbolProcessor(
     environment: SymbolProcessorEnvironment

--- a/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/RepositoryBuilder.java
+++ b/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/RepositoryBuilder.java
@@ -5,23 +5,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ru.tinkoff.kora.annotation.processor.common.CommonUtils;
 import ru.tinkoff.kora.annotation.processor.common.ProcessingErrorException;
+import ru.tinkoff.kora.common.annotation.Generated;
 import ru.tinkoff.kora.database.annotation.processor.cassandra.CassandraRepositoryGenerator;
 import ru.tinkoff.kora.database.annotation.processor.jdbc.JdbcRepositoryGenerator;
 import ru.tinkoff.kora.database.annotation.processor.r2dbc.R2DbcRepositoryGenerator;
 import ru.tinkoff.kora.database.annotation.processor.vertx.VertxRepositoryGenerator;
 
 import javax.annotation.Nullable;
-import javax.annotation.processing.Generated;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Types;
 import java.io.IOException;
-import java.lang.annotation.Annotation;
-import java.util.*;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.List;
 
 public class RepositoryBuilder {
     private static final Logger log = LoggerFactory.getLogger(RepositoryBuilder.class);

--- a/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/cassandra/extension/CassandraTypesExtension.java
+++ b/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/cassandra/extension/CassandraTypesExtension.java
@@ -2,6 +2,7 @@ package ru.tinkoff.kora.database.annotation.processor.cassandra.extension;
 
 import com.squareup.javapoet.*;
 import ru.tinkoff.kora.annotation.processor.common.CommonUtils;
+import ru.tinkoff.kora.common.annotation.Generated;
 import ru.tinkoff.kora.database.annotation.processor.DbEntityReadHelper;
 import ru.tinkoff.kora.database.annotation.processor.cassandra.CassandraNativeTypes;
 import ru.tinkoff.kora.database.annotation.processor.cassandra.CassandraTypes;
@@ -11,7 +12,6 @@ import ru.tinkoff.kora.kora.app.annotation.processor.extension.KoraExtension;
 
 import javax.annotation.Nullable;
 import javax.annotation.processing.Filer;
-import javax.annotation.processing.Generated;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.Modifier;

--- a/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/jdbc/extension/JdbcTypesExtension.java
+++ b/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/jdbc/extension/JdbcTypesExtension.java
@@ -3,6 +3,7 @@ package ru.tinkoff.kora.database.annotation.processor.jdbc.extension;
 import com.squareup.javapoet.*;
 import ru.tinkoff.kora.annotation.processor.common.CommonUtils;
 import ru.tinkoff.kora.annotation.processor.common.GenericTypeResolver;
+import ru.tinkoff.kora.common.annotation.Generated;
 import ru.tinkoff.kora.database.annotation.processor.DbEntityReadHelper;
 import ru.tinkoff.kora.database.annotation.processor.entity.DbEntity;
 import ru.tinkoff.kora.database.annotation.processor.jdbc.JdbcNativeTypes;
@@ -12,7 +13,6 @@ import ru.tinkoff.kora.kora.app.annotation.processor.extension.KoraExtension;
 
 import javax.annotation.Nullable;
 import javax.annotation.processing.Filer;
-import javax.annotation.processing.Generated;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.ElementKind;

--- a/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/r2dbc/extension/R2dbcTypesExtension.java
+++ b/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/r2dbc/extension/R2dbcTypesExtension.java
@@ -2,6 +2,7 @@ package ru.tinkoff.kora.database.annotation.processor.r2dbc.extension;
 
 import com.squareup.javapoet.*;
 import ru.tinkoff.kora.annotation.processor.common.CommonUtils;
+import ru.tinkoff.kora.common.annotation.Generated;
 import ru.tinkoff.kora.database.annotation.processor.DbEntityReadHelper;
 import ru.tinkoff.kora.database.annotation.processor.entity.DbEntity;
 import ru.tinkoff.kora.database.annotation.processor.r2dbc.R2dbcNativeTypes;
@@ -11,7 +12,6 @@ import ru.tinkoff.kora.kora.app.annotation.processor.extension.KoraExtension;
 
 import javax.annotation.Nullable;
 import javax.annotation.processing.Filer;
-import javax.annotation.processing.Generated;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.Modifier;

--- a/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/vertx/extension/VertxTypesExtension.java
+++ b/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/vertx/extension/VertxTypesExtension.java
@@ -2,6 +2,7 @@ package ru.tinkoff.kora.database.annotation.processor.vertx.extension;
 
 import com.squareup.javapoet.*;
 import ru.tinkoff.kora.annotation.processor.common.CommonUtils;
+import ru.tinkoff.kora.common.annotation.Generated;
 import ru.tinkoff.kora.database.annotation.processor.DbEntityReadHelper;
 import ru.tinkoff.kora.database.annotation.processor.entity.DbEntity;
 import ru.tinkoff.kora.database.annotation.processor.vertx.VertxNativeTypes;
@@ -11,7 +12,6 @@ import ru.tinkoff.kora.kora.app.annotation.processor.extension.KoraExtension;
 
 import javax.annotation.Nullable;
 import javax.annotation.processing.Filer;
-import javax.annotation.processing.Generated;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.Modifier;

--- a/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/cassandra/extension/CassandraTypesExtension.kt
+++ b/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/cassandra/extension/CassandraTypesExtension.kt
@@ -10,6 +10,7 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
+import ru.tinkoff.kora.common.annotation.Generated
 import ru.tinkoff.kora.database.symbol.processor.DbEntityReader
 import ru.tinkoff.kora.database.symbol.processor.cassandra.CassandraNativeTypes
 import ru.tinkoff.kora.database.symbol.processor.cassandra.CassandraTypes
@@ -18,7 +19,6 @@ import ru.tinkoff.kora.kora.app.ksp.extension.ExtensionResult
 import ru.tinkoff.kora.kora.app.ksp.extension.KoraExtension
 import ru.tinkoff.kora.ksp.common.CommonClassNames.isList
 import ru.tinkoff.kora.ksp.common.getOuterClassesAsPrefix
-import javax.annotation.processing.Generated
 
 //CassandraRowMapper<T>
 //CassandraResultSetMapper<List<T>>

--- a/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/jdbc/extension/JdbcTypesExtension.kt
+++ b/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/jdbc/extension/JdbcTypesExtension.kt
@@ -9,6 +9,7 @@ import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
+import ru.tinkoff.kora.common.annotation.Generated
 import ru.tinkoff.kora.database.symbol.processor.DbEntityReader
 import ru.tinkoff.kora.database.symbol.processor.jdbc.JdbcNativeTypes
 import ru.tinkoff.kora.database.symbol.processor.jdbc.JdbcTypes
@@ -18,7 +19,6 @@ import ru.tinkoff.kora.kora.app.ksp.extension.KoraExtension
 import ru.tinkoff.kora.ksp.common.CommonClassNames.isList
 import ru.tinkoff.kora.ksp.common.KotlinPoetUtils.controlFlow
 import ru.tinkoff.kora.ksp.common.getOuterClassesAsPrefix
-import javax.annotation.processing.Generated
 
 // JdbcRowMapper<T>
 // JdbcResultSetMapper<List<T>>

--- a/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/r2dbc/extension/R2dbcTypesExtension.kt
+++ b/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/r2dbc/extension/R2dbcTypesExtension.kt
@@ -10,6 +10,7 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
+import ru.tinkoff.kora.common.annotation.Generated
 import ru.tinkoff.kora.database.symbol.processor.DbEntityReader
 import ru.tinkoff.kora.database.symbol.processor.model.DbEntity
 import ru.tinkoff.kora.database.symbol.processor.r2dbc.R2dbcNativeTypes
@@ -17,7 +18,6 @@ import ru.tinkoff.kora.database.symbol.processor.r2dbc.R2dbcTypes
 import ru.tinkoff.kora.kora.app.ksp.extension.ExtensionResult
 import ru.tinkoff.kora.kora.app.ksp.extension.KoraExtension
 import ru.tinkoff.kora.ksp.common.getOuterClassesAsPrefix
-import javax.annotation.processing.Generated
 
 //R2dbcRowMapper<T>
 class R2dbcTypesExtension(val resolver: Resolver, val kspLogger: KSPLogger, val codeGenerator: CodeGenerator) : KoraExtension {

--- a/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/vertx/extension/VertxTypesExtension.kt
+++ b/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/vertx/extension/VertxTypesExtension.kt
@@ -9,6 +9,7 @@ import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
+import ru.tinkoff.kora.common.annotation.Generated
 import ru.tinkoff.kora.database.symbol.processor.DbEntityReader
 import ru.tinkoff.kora.database.symbol.processor.model.DbEntity
 import ru.tinkoff.kora.database.symbol.processor.vertx.VertxNativeTypes
@@ -17,7 +18,6 @@ import ru.tinkoff.kora.kora.app.ksp.extension.ExtensionResult
 import ru.tinkoff.kora.kora.app.ksp.extension.KoraExtension
 import ru.tinkoff.kora.ksp.common.KotlinPoetUtils.controlFlow
 import ru.tinkoff.kora.ksp.common.getOuterClassesAsPrefix
-import javax.annotation.processing.Generated
 
 //RowMapper<T>
 //RowSetMapper<List<T>>

--- a/http/http-client-annotation-processor/src/main/java/ru/tinkoff/kora/http/client/annotation/processor/ClientClassGenerator.java
+++ b/http/http-client-annotation-processor/src/main/java/ru/tinkoff/kora/http/client/annotation/processor/ClientClassGenerator.java
@@ -6,6 +6,7 @@ import reactor.core.publisher.Mono;
 import ru.tinkoff.kora.annotation.processor.common.CommonUtils;
 import ru.tinkoff.kora.annotation.processor.common.ComparableTypeMirror;
 import ru.tinkoff.kora.common.Tag;
+import ru.tinkoff.kora.common.annotation.Generated;
 import ru.tinkoff.kora.http.client.common.HttpClient;
 import ru.tinkoff.kora.http.client.common.HttpClientException;
 import ru.tinkoff.kora.http.client.common.HttpClientResponseException;
@@ -19,7 +20,6 @@ import ru.tinkoff.kora.http.client.common.writer.StringParameterConverter;
 import ru.tinkoff.kora.http.common.annotation.HttpRoute;
 
 import javax.annotation.Nullable;
-import javax.annotation.processing.Generated;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.*;
 import javax.lang.model.type.DeclaredType;

--- a/http/http-client-annotation-processor/src/main/java/ru/tinkoff/kora/http/client/annotation/processor/ConfigModuleGenerator.java
+++ b/http/http-client-annotation-processor/src/main/java/ru/tinkoff/kora/http/client/annotation/processor/ConfigModuleGenerator.java
@@ -3,10 +3,10 @@ package ru.tinkoff.kora.http.client.annotation.processor;
 import com.squareup.javapoet.*;
 import com.typesafe.config.Config;
 import ru.tinkoff.kora.common.Module;
+import ru.tinkoff.kora.common.annotation.Generated;
 import ru.tinkoff.kora.config.common.extractor.ConfigValueExtractor;
 import ru.tinkoff.kora.http.client.common.annotation.HttpClient;
 
-import javax.annotation.processing.Generated;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;

--- a/http/http-client-symbol-processor/src/main/kotlin/ru/tinkoff/kora/http/client/symbol/processor/ClientClassGenerator.kt
+++ b/http/http-client-symbol-processor/src/main/kotlin/ru/tinkoff/kora/http/client/symbol/processor/ClientClassGenerator.kt
@@ -12,6 +12,7 @@ import com.squareup.kotlinpoet.ksp.toTypeParameterResolver
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import ru.tinkoff.kora.common.Tag
+import ru.tinkoff.kora.common.annotation.Generated
 import ru.tinkoff.kora.http.client.common.HttpClient
 import ru.tinkoff.kora.http.client.common.HttpClientException
 import ru.tinkoff.kora.http.client.common.HttpClientResponseException
@@ -27,14 +28,15 @@ import ru.tinkoff.kora.http.common.annotation.HttpRoute
 import ru.tinkoff.kora.kora.app.ksp.extendsKeepAop
 import ru.tinkoff.kora.kora.app.ksp.hasAopAnnotations
 import ru.tinkoff.kora.kora.app.ksp.overridingKeepAop
-import ru.tinkoff.kora.ksp.common.*
 import ru.tinkoff.kora.ksp.common.AnnotationUtils.findAnnotation
 import ru.tinkoff.kora.ksp.common.AnnotationUtils.findValue
 import ru.tinkoff.kora.ksp.common.KotlinPoetUtils.controlFlow
 import ru.tinkoff.kora.ksp.common.KotlinPoetUtils.writeTagValue
 import ru.tinkoff.kora.ksp.common.KspCommonUtils.findRepeatableAnnotation
+import ru.tinkoff.kora.ksp.common.MappingData
+import ru.tinkoff.kora.ksp.common.parseAnnotationValue
+import ru.tinkoff.kora.ksp.common.parseMappingData
 import java.util.*
-import javax.annotation.processing.Generated
 
 @KspExperimental
 class ClientClassGenerator(private val resolver: Resolver) {

--- a/http/http-client-symbol-processor/src/main/kotlin/ru/tinkoff/kora/http/client/symbol/processor/ConfigModuleGenerator.kt
+++ b/http/http-client-symbol-processor/src/main/kotlin/ru/tinkoff/kora/http/client/symbol/processor/ConfigModuleGenerator.kt
@@ -9,9 +9,9 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
 import com.typesafe.config.Config
 import ru.tinkoff.kora.common.Module
+import ru.tinkoff.kora.common.annotation.Generated
 import ru.tinkoff.kora.config.common.extractor.ConfigValueExtractor
 import ru.tinkoff.kora.http.client.common.annotation.HttpClient
-import javax.annotation.processing.Generated
 
 @KspExperimental
 class ConfigModuleGenerator(val resolver: Resolver) {

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/JsonReaderGenerator.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/JsonReaderGenerator.java
@@ -6,16 +6,15 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.io.SerializedString;
 import com.squareup.javapoet.*;
 import ru.tinkoff.kora.annotation.processor.common.CommonUtils;
+import ru.tinkoff.kora.common.annotation.Generated;
 import ru.tinkoff.kora.json.annotation.processor.JsonUtils;
 import ru.tinkoff.kora.json.annotation.processor.KnownType;
 import ru.tinkoff.kora.json.annotation.processor.reader.JsonClassReaderMeta.FieldMeta;
 import ru.tinkoff.kora.json.annotation.processor.reader.ReaderFieldType.KnownTypeReaderMeta;
 import ru.tinkoff.kora.json.common.EnumJsonReader;
-import ru.tinkoff.kora.json.common.JsonObjectCodec;
 import ru.tinkoff.kora.json.common.JsonReader;
 
 import javax.annotation.Nullable;
-import javax.annotation.processing.Generated;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/SealedInterfaceReaderGenerator.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/reader/SealedInterfaceReaderGenerator.java
@@ -3,6 +3,7 @@ package ru.tinkoff.kora.json.annotation.processor.reader;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.squareup.javapoet.*;
+import ru.tinkoff.kora.common.annotation.Generated;
 import ru.tinkoff.kora.json.annotation.processor.JsonUtils;
 import ru.tinkoff.kora.json.annotation.processor.KnownType;
 import ru.tinkoff.kora.json.common.BufferedParserWithDiscriminator;
@@ -11,7 +12,6 @@ import ru.tinkoff.kora.json.common.annotation.JsonDiscriminatorValue;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.annotation.processing.Generated;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/writer/JsonWriterGenerator.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/writer/JsonWriterGenerator.java
@@ -3,16 +3,15 @@ package ru.tinkoff.kora.json.annotation.processor.writer;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.io.SerializedString;
 import com.squareup.javapoet.*;
+import ru.tinkoff.kora.common.annotation.Generated;
 import ru.tinkoff.kora.json.annotation.processor.JsonUtils;
 import ru.tinkoff.kora.json.annotation.processor.KnownType;
 import ru.tinkoff.kora.json.annotation.processor.writer.JsonClassWriterMeta.FieldMeta;
 import ru.tinkoff.kora.json.common.EnumJsonWriter;
-import ru.tinkoff.kora.json.common.JsonObjectCodec;
 import ru.tinkoff.kora.json.common.JsonWriter;
 import ru.tinkoff.kora.json.common.annotation.JsonDiscriminatorValue;
 
 import javax.annotation.Nullable;
-import javax.annotation.processing.Generated;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/writer/SealedInterfaceWriterGenerator.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/writer/SealedInterfaceWriterGenerator.java
@@ -2,12 +2,12 @@ package ru.tinkoff.kora.json.annotation.processor.writer;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.squareup.javapoet.*;
+import ru.tinkoff.kora.common.annotation.Generated;
 import ru.tinkoff.kora.json.annotation.processor.JsonUtils;
 import ru.tinkoff.kora.json.common.JsonWriter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.annotation.processing.Generated;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/reader/JsonReaderGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/reader/JsonReaderGenerator.kt
@@ -12,6 +12,7 @@ import com.google.devtools.ksp.symbol.Modifier
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.ksp.*
+import ru.tinkoff.kora.common.annotation.Generated
 import ru.tinkoff.kora.json.common.EnumJsonReader
 import ru.tinkoff.kora.json.common.JsonReader
 import ru.tinkoff.kora.json.ksp.KnownType.KnownTypesEnum
@@ -23,7 +24,6 @@ import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.*
 import java.util.UUID
-import javax.annotation.processing.Generated
 
 class JsonReaderGenerator(val resolver: Resolver) {
     companion object {

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/reader/SealedInterfaceReaderGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/reader/SealedInterfaceReaderGenerator.kt
@@ -14,13 +14,13 @@ import com.google.devtools.ksp.symbol.KSTypeReference
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.ksp.*
+import ru.tinkoff.kora.common.annotation.Generated
 import ru.tinkoff.kora.json.common.BufferedParserWithDiscriminator
 import ru.tinkoff.kora.json.common.JsonReader
 import ru.tinkoff.kora.json.common.annotation.JsonDiscriminatorValue
 import ru.tinkoff.kora.json.ksp.KnownType
 import ru.tinkoff.kora.json.ksp.jsonReaderName
 import ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException
-import javax.annotation.processing.Generated
 
 @KspExperimental
 class SealedInterfaceReaderGenerator(private val resolver: Resolver, logger: KSPLogger) {

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/JsonWriterGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/JsonWriterGenerator.kt
@@ -11,15 +11,14 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.ksp.*
+import ru.tinkoff.kora.common.annotation.Generated
 import ru.tinkoff.kora.json.common.EnumJsonWriter
-import ru.tinkoff.kora.json.common.JsonObjectCodec
 import ru.tinkoff.kora.json.common.JsonWriter
 import ru.tinkoff.kora.json.common.annotation.JsonDiscriminatorValue
 import ru.tinkoff.kora.json.ksp.KnownType.KnownTypesEnum
 import ru.tinkoff.kora.json.ksp.KnownType.KnownTypesEnum.*
 import ru.tinkoff.kora.json.ksp.jsonWriterName
 import ru.tinkoff.kora.ksp.common.KotlinPoetUtils.controlFlow
-import javax.annotation.processing.Generated
 
 @KspExperimental
 class JsonWriterGenerator(

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/SealedInterfaceWriterGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/SealedInterfaceWriterGenerator.kt
@@ -10,11 +10,11 @@ import com.google.devtools.ksp.symbol.KSTypeReference
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.ksp.*
+import ru.tinkoff.kora.common.annotation.Generated
 import ru.tinkoff.kora.json.common.JsonWriter
 import ru.tinkoff.kora.json.ksp.jsonWriterName
 import ru.tinkoff.kora.ksp.common.KotlinPoetUtils.controlFlow
 import ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException
-import javax.annotation.processing.Generated
 
 @OptIn(KspExperimental::class)
 class SealedInterfaceWriterGenerator(

--- a/kora-app-annotation-processor/src/main/java/ru/tinkoff/kora/kora/app/annotation/processor/KoraAppProcessor.java
+++ b/kora-app-annotation-processor/src/main/java/ru/tinkoff/kora/kora/app/annotation/processor/KoraAppProcessor.java
@@ -16,7 +16,10 @@ import ru.tinkoff.kora.kora.app.annotation.processor.exception.NewRoundException
 import ru.tinkoff.kora.kora.app.annotation.processor.interceptor.ComponentInterceptors;
 
 import javax.annotation.Nullable;
-import javax.annotation.processing.*;
+import javax.annotation.processing.FilerException;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.*;
 import javax.lang.model.type.DeclaredType;
@@ -62,7 +65,7 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
         if (!this.initialized) {
             return Set.of();
         }
-        return Set.of(CommonClassNames.koraApp.canonicalName(), CommonClassNames.module.canonicalName(), CommonClassNames.component.canonicalName(), CommonClassNames.koraSubmodule.canonicalName(), Generated.class.getCanonicalName());
+        return Set.of(CommonClassNames.koraApp.canonicalName(), CommonClassNames.module.canonicalName(), CommonClassNames.component.canonicalName(), CommonClassNames.koraSubmodule.canonicalName(), CommonClassNames.koraGenerated.canonicalName());
     }
 
     @Override
@@ -171,7 +174,7 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
     }
 
     private void processGenerated(RoundEnvironment roundEnv) {
-        log.info("Generated from prev round:\n{}", roundEnv.getElementsAnnotatedWith(Generated.class)
+        log.info("Generated from prev round:\n{}", roundEnv.getElementsAnnotatedWith(ru.tinkoff.kora.common.annotation.Generated.class)
             .stream()
             .map(Object::toString)
             .collect(Collectors.joining("\n"))
@@ -439,7 +442,7 @@ public class KoraAppProcessor extends AbstractKoraProcessor {
             statement.add("(");
         } else if (declaration instanceof ComponentDeclaration.OptionalComponent optional) {
             statement.add("$T", Optional.class);
-            statement.add(".<$T>ofNullable(", ((DeclaredType)optional.type()).getTypeArguments().get(0));
+            statement.add(".<$T>ofNullable(", ((DeclaredType) optional.type()).getTypeArguments().get(0));
         } else {
             throw new RuntimeException("Unknown type " + declaration);
         }

--- a/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/KoraAppProcessor.kt
+++ b/kora-app-symbol-processor/src/main/kotlin/ru/tinkoff/kora/kora/app/ksp/KoraAppProcessor.kt
@@ -14,6 +14,7 @@ import com.squareup.kotlinpoet.ksp.writeTo
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import ru.tinkoff.kora.application.graph.ApplicationGraphDraw
+import ru.tinkoff.kora.common.annotation.Generated
 import ru.tinkoff.kora.kora.app.ksp.component.ComponentDependency
 import ru.tinkoff.kora.kora.app.ksp.component.DependencyClaim
 import ru.tinkoff.kora.kora.app.ksp.component.ResolvedComponent
@@ -31,7 +32,6 @@ import java.util.*
 import java.util.concurrent.atomic.AtomicReference
 import java.util.function.Function
 import java.util.function.Supplier
-import javax.annotation.processing.Generated
 import javax.annotation.processing.SupportedOptions
 
 @KspExperimental

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaApiResponses.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaApiResponses.mustache
@@ -3,7 +3,7 @@ package {{package}};
 {{#imports}}import {{import}};
 {{/imports}}
 
-@javax.annotation.processing.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 public interface {{classname}}Responses {
 {{#operations}}
 {{#operation}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientApi.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientApi.mustache
@@ -20,7 +20,7 @@ import ru.tinkoff.kora.http.common.annotation.InterceptWith;
 import ru.tinkoff.kora.http.client.common.interceptor.HttpClientInterceptor;
 {{/hasAuthMethods}}
 
-@javax.annotation.processing.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 @HttpClient{{{annotationParams}}}
 public interface {{classname}} {
 {{#operations}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientRequestMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientRequestMappers.mustache
@@ -6,7 +6,7 @@ import ru.tinkoff.kora.http.client.common.request.HttpClientRequestMapper;
 import ru.tinkoff.kora.http.client.common.request.HttpClientRequestBuilder;
 import reactor.core.publisher.Mono;
 
-@javax.annotation.processing.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 public interface {{classname}}ClientRequestMappers {
 {{#operations}}
 {{#operation}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientResponseMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientResponseMappers.mustache
@@ -8,7 +8,7 @@ import {{package}}.{{classname}}Responses.*;
 {{#imports}}import {{import}};
 {{/imports}}
 
-@javax.annotation.processing.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 public interface {{classname}}ClientResponseMappers {
 {{#operations}}
 {{#operation}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientSecuritySchema.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaClientSecuritySchema.mustache
@@ -18,7 +18,7 @@ import ru.tinkoff.kora.http.client.common.auth.*;
 
 
 @Module
-@javax.annotation.processing.Generated("openapi generator kora client")
+@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client")
 public interface ApiSecurity {
 {{#authMethods}}
     static final class {{#lambda.classname}}{{name}}{{/lambda.classname}} {}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaModel.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaModel.mustache
@@ -29,7 +29,7 @@ public sealed interface {{classname}} permits {{#mappedModels}}{{modelName}}{{^-
 {{^discriminator}}
 {{^additionalConstructor}}@ru.tinkoff.kora.json.common.annotation.JsonReader
 {{/additionalConstructor}}@ru.tinkoff.kora.json.common.annotation.JsonWriter
-@javax.annotation.processing.Generated("openapi generator kora client")
+@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client")
 {{#vendorExtensions.x-discriminator-value}}@JsonDiscriminatorValue("{{vendorExtensions.x-discriminator-value}}"){{/vendorExtensions.x-discriminator-value}}
 public record {{classname}} (
 {{#allVars}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerApi.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerApi.mustache
@@ -20,7 +20,7 @@ import ru.tinkoff.kora.http.server.common.HttpServerInterceptor;
 {{/hasAuthMethods}}
 
 
-@javax.annotation.processing.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 @HttpController
 public final class {{classname}}Controller {
     private final {{classname}}Delegate delegate;

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerApiDelegate.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerApiDelegate.mustache
@@ -11,7 +11,7 @@ package {{package}};
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.processing.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 public interface {{classname}}Delegate {
 {{#operations}}
 {{#operation}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerRequestMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerRequestMappers.mustache
@@ -5,7 +5,7 @@ import ru.tinkoff.kora.http.server.common.handler.HttpServerRequestMapper;
 import ru.tinkoff.kora.http.server.common.HttpServerRequest;
 import reactor.core.publisher.Mono;
 
-@javax.annotation.processing.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 public interface {{classname}}ServerRequestMappers {
 {{#operations}}
 {{#operation}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerResponseMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerResponseMappers.mustache
@@ -11,7 +11,7 @@ import {{package}}.{{classname}}Responses.*;
 {{#imports}}import {{import}};
 {{/imports}}
 
-@javax.annotation.processing.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 public interface {{classname}}ServerResponseMappers {
 {{#operations}}
 {{#operation}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerSecuritySchema.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/javaServerSecuritySchema.mustache
@@ -27,7 +27,7 @@ import ru.tinkoff.kora.http.server.common.auth.*;
 
 
 @Module
-@javax.annotation.processing.Generated("openapi generator kora client")
+@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client")
 public interface ApiSecurity {
 {{#vendorExtensions.tags}}
     static final class {{.}} {}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinApiResponses.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinApiResponses.mustache
@@ -3,7 +3,7 @@ package {{package}}
 {{#imports}}import {{import}}
 {{/imports}}
 
-//@javax.annotation.processing.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+//@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 interface {{classname}}Responses {
 {{#operations}}
 {{#operation}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientApi.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientApi.mustache
@@ -18,7 +18,7 @@ import ru.tinkoff.kora.http.common.annotation.InterceptWith;
 import ru.tinkoff.kora.http.client.common.interceptor.HttpClientInterceptor;
 {{/hasAuthMethods}}
 
-//@javax.annotation.processing.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+//@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 @HttpClient{{{annotationParams}}}
 interface {{classname}} {
 {{#operations}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientRequestMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientRequestMappers.mustache
@@ -6,7 +6,7 @@ import ru.tinkoff.kora.http.client.common.request.HttpClientRequestMapper
 import ru.tinkoff.kora.http.client.common.request.HttpClientRequestBuilder
 import reactor.core.publisher.Mono
 
-//@javax.annotation.processing.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+//@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 interface {{classname}}ClientRequestMappers {
 {{#operations}}
 {{#operation}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientResponseMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientResponseMappers.mustache
@@ -8,7 +8,7 @@ import {{package}}.{{classname}}Responses.*
 {{#imports}}import {{import}}
 {{/imports}}
 
-//@javax.annotation.processing.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+//@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 interface {{classname}}ClientResponseMappers {
 {{#operations}}
 {{#operation}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientSecuritySchema.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinClientSecuritySchema.mustache
@@ -18,7 +18,7 @@ import ru.tinkoff.kora.http.client.common.auth.*
 
 
 @Module
-//@javax.annotation.processing.Generated("openapi generator kora client")
+//@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client")
 interface ApiSecurity {
 {{#authMethods}}
 

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinModel.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinModel.mustache
@@ -29,7 +29,7 @@ sealed interface {{classname}}
 {{/discriminator}}
 {{^discriminator}}
 @ru.tinkoff.kora.json.common.annotation.JsonWriter
-//@javax.annotation.processing.Generated("openapi generator kora client")
+//@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client")
 {{#vendorExtensions.x-discriminator-value}}@ru.tinkoff.kora.json.common.annotation.JsonDiscriminatorValue("{{vendorExtensions.x-discriminator-value}}"){{/vendorExtensions.x-discriminator-value}}
 {{#hasVars}}data {{/hasVars}}class {{classname}} @ru.tinkoff.kora.json.common.annotation.JsonReader constructor (
 {{#allVars}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerApi.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerApi.mustache
@@ -17,7 +17,7 @@ import ru.tinkoff.kora.common.Tag;
 import ru.tinkoff.kora.http.common.annotation.InterceptWith;
 import ru.tinkoff.kora.http.server.common.HttpServerInterceptor;
 {{/hasAuthMethods}}
-//@javax.annotation.processing.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+//@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 @HttpController
 class {{classname}}Controller(private val delegate: {{classname}}Delegate) {
 {{#operations}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerApiDelegate.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerApiDelegate.mustache
@@ -8,7 +8,7 @@ package {{package}}
 {{#imports}}import {{import}}
 {{/imports}}
 
-// @javax.annotation.processing.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+// @ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 interface {{classname}}Delegate {
 {{#operations}}
 {{#operation}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerRequestMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerRequestMappers.mustache
@@ -5,7 +5,7 @@ import ru.tinkoff.kora.http.server.common.handler.HttpServerRequestMapper
 import ru.tinkoff.kora.http.server.common.HttpServerRequest
 import reactor.core.publisher.Mono
 
-//@javax.annotation.processing.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+//@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 interface {{classname}}ServerRequestMappers {
 {{#operations}}
 {{#operation}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerResponseMappers.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerResponseMappers.mustache
@@ -12,7 +12,7 @@ import {{package}}.{{classname}}Responses.*
 {{#imports}}import {{import}}
 {{/imports}}
 
-//@javax.annotation.processing.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+//@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 interface {{classname}}ServerResponseMappers {
 {{#operations}}
 {{#operation}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerSecuritySchema.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/kotlinServerSecuritySchema.mustache
@@ -27,7 +27,7 @@ import ru.tinkoff.kora.http.server.common.auth.*
 
 
 @Module
-@javax.annotation.processing.Generated("openapi generator kora client")
+@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client")
 public interface ApiSecurity {
 {{#vendorExtensions.tags}}
     class {{.}} {}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/reactiveClientApi.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/reactiveClientApi.mustache
@@ -22,7 +22,7 @@ import ru.tinkoff.kora.http.common.annotation.InterceptWith;
 import ru.tinkoff.kora.http.client.common.interceptor.HttpClientInterceptor;
 {{/hasAuthMethods}}
 
-@javax.annotation.processing.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 @HttpClient{{{annotationParams}}}
 public interface {{classname}} {
 {{#operations}}

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/reactiveServerApi.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/reactiveServerApi.mustache
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 import ru.tinkoff.kora.common.Mapping;
 
-@javax.annotation.processing.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 @ru.tinkoff.kora.http.server.common.annotation.HttpController
 public final class {{classname}}Controller {
     private final {{classname}}Delegate delegate;

--- a/openapi/openapi-generator/src/main/resources/openapi/templates/kora/reactiveServerApiDelegate.mustache
+++ b/openapi/openapi-generator/src/main/resources/openapi/templates/kora/reactiveServerApiDelegate.mustache
@@ -12,7 +12,7 @@ import reactor.core.publisher.Mono;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.processing.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
+@ru.tinkoff.kora.common.annotation.Generated("openapi generator kora client"){{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 public interface {{classname}}Delegate {
 {{#operations}}
 {{#operation}}


### PR DESCRIPTION
JaCoCo detects and filters out generated methods by any annotation with simple name `Generated` and with retention `CLASS` or higher. So we have to introduce our own `@Generated` to use on generated source files.