### PR TITLE
Correct unresolved dependency message for multiple templates matching same type

### DIFF
--- a/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/GenericTypeResolver.java
+++ b/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/GenericTypeResolver.java
@@ -70,7 +70,7 @@ public class GenericTypeResolver {
                 var thrownTypes = t.getThrownTypes();
                 var enrichedReturnType = returnType.accept(this, null);
                 var enrichedParameterTypes = parameterTypes.stream().map(pt -> pt.accept(this, null)).toList();
-                var enrichedReceiverType = receiverType.accept(this, null);
+                var enrichedReceiverType = receiverType != null ? receiverType.accept(this, null) : null;
                 var enrichedThrownTypes = thrownTypes.stream().map(pt -> pt.accept(this, null)).toList();
                 var element = (ExecutableElement) types.asElement(t);
                 if (returnType != enrichedReturnType) {

--- a/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/ProcessingError.java
+++ b/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/ProcessingError.java
@@ -20,6 +20,10 @@ public record ProcessingError(Diagnostic.Kind kind, String message, Element elem
     }
 
     public void print(ProcessingEnvironment processingEnvironment) {
+        this.print(0, processingEnvironment);
+    }
+
+    public void print(int indent, ProcessingEnvironment processingEnvironment) {
         var element = this.element();
 
         if (element != null) for (var enclosedElement : element.getEnclosingElement().getEnclosedElements()) {
@@ -27,8 +31,11 @@ public record ProcessingError(Diagnostic.Kind kind, String message, Element elem
                 element = enclosedElement;
             }
         }
-
-        processingEnvironment.getMessager().printMessage(kind, this.message(), element, this.a(), this.v());
+        var message = this.message();
+        if (indent > 0) {
+            message = message.indent(indent);
+        }
+        processingEnvironment.getMessager().printMessage(kind, message, element, this.a(), this.v());
     }
 
 
@@ -59,4 +66,5 @@ public record ProcessingError(Diagnostic.Kind kind, String message, Element elem
             kind, message.indent(i), element, a, v
         );
     }
+
 }

--- a/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/ProcessingErrorException.java
+++ b/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/ProcessingErrorException.java
@@ -58,8 +58,17 @@ public class ProcessingErrorException extends RuntimeException {
     }
 
     public void printError(ProcessingEnvironment processingEnv) {
+        this.printError(0, processingEnv);
+    }
+
+    private void printError(int indent, ProcessingEnvironment processingEnv) {
         for (var error : this.errors) {
-            error.print(processingEnv);
+            error.print(indent, processingEnv);
+        }
+        for (var supressed : this.getSuppressed()) {
+            if (supressed instanceof ProcessingErrorException e) {
+                e.printError(indent + 6, processingEnv);
+            }
         }
     }
 }

--- a/database/database-jdbc/src/main/resources/modules.json
+++ b/database/database-jdbc/src/main/resources/modules.json
@@ -1,14 +1,8 @@
 [
     {
         "tags": [],
-        "typeRegex": "ru.tinkoff.kora.database.jdbc.JdbcQueryExecutor",
-        "moduleName": "ru.tinkoff.kora.database.jdbc.DatabaseModule",
-        "artifact": "ru.tinkoff.kora:database-jdbc"
-    },
-    {
-        "tags": [],
-        "typeRegex": "ru.tinkoff.kora.database.jdbc.JdbcQueryExecutor",
-        "moduleName": "ru.tinkoff.kora.database.jdbc.JdbcDataBase",
+        "typeRegex": "ru.tinkoff.kora.database.jdbc.JdbcConnectionFactory",
+        "moduleName": "ru.tinkoff.kora.database.jdbc.JdbcDatabaseModule",
         "artifact": "ru.tinkoff.kora:database-jdbc"
     }
 ]


### PR DESCRIPTION
Now multiple template resolution process stops after resolving all template dependencies and returns to callee, so some deep unresolved dependency errors won't be lost.