### PR TITLE
`@Nullable` presence check should look at field element in addition to record component

### DIFF
--- a/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/CommonUtils.java
+++ b/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/CommonUtils.java
@@ -39,9 +39,17 @@ public class CommonUtils {
     }
 
     public static boolean isNullable(Element element) {
-        return element.getAnnotationMirrors()
+        var isNullable = element.getAnnotationMirrors()
             .stream()
             .anyMatch(a -> a.getAnnotationType().toString().endsWith(".Nullable"));
+        if (isNullable || element.getKind() != ElementKind.RECORD_COMPONENT) {
+            return isNullable;
+        }
+        return element.getEnclosingElement().getEnclosedElements()
+            .stream()
+            .filter(e -> e.getKind() == ElementKind.FIELD)
+            .filter(e -> e.getSimpleName().contentEquals(element.getSimpleName()))
+            .anyMatch(CommonUtils::isNullable);
     }
 
     public static void safeWriteTo(ProcessingEnvironment processingEnv, JavaFile file) throws IOException {


### PR DESCRIPTION
Annotations like `org.jetbrains.annotations.Nullable` have no record component in targets, so we should check field too.