### PR TITLE
Added schema in database property

### DIFF
--- a/database/database-flyway/src/test/java/ru/tinkoff/kora/database/flyway/FlywayJdbcDatabaseInterceptorTest.java
+++ b/database/database-flyway/src/test/java/ru/tinkoff/kora/database/flyway/FlywayJdbcDatabaseInterceptorTest.java
@@ -22,6 +22,7 @@ public class FlywayJdbcDatabaseInterceptorTest {
             params.password(),
             params.jdbcUrl(),
             "testPool",
+            null,
             1000L,
             1000L,
             1000L,

--- a/database/database-jdbc/src/main/java/ru/tinkoff/kora/database/jdbc/JdbcDataBaseConfig.java
+++ b/database/database-jdbc/src/main/java/ru/tinkoff/kora/database/jdbc/JdbcDataBaseConfig.java
@@ -10,6 +10,7 @@ public record JdbcDataBaseConfig(
     String password,
     String jdbcUrl,
     String poolName,
+    @Nullable
     String schema,
     long connectionTimeout,
     long validationTimeout,

--- a/database/database-jdbc/src/main/java/ru/tinkoff/kora/database/jdbc/JdbcDataBaseConfig.java
+++ b/database/database-jdbc/src/main/java/ru/tinkoff/kora/database/jdbc/JdbcDataBaseConfig.java
@@ -10,6 +10,7 @@ public record JdbcDataBaseConfig(
     String password,
     String jdbcUrl,
     String poolName,
+    String schema,
     long connectionTimeout,
     long validationTimeout,
     long idleTimeout,
@@ -25,6 +26,7 @@ public record JdbcDataBaseConfig(
         String password,
         String jdbcUrl,
         String poolName,
+        @Nullable String schema,
         @Nullable Long connectionTimeout,
         @Nullable Long validationTimeout,
         @Nullable Long idleTimeout,
@@ -37,6 +39,7 @@ public record JdbcDataBaseConfig(
             password,
             jdbcUrl,
             poolName,
+            schema,
             connectionTimeout != null ? connectionTimeout : 30000,
             validationTimeout != null ? validationTimeout : 5000,
             idleTimeout != null ? idleTimeout : 10 * 60 * 1000,
@@ -73,7 +76,7 @@ public record JdbcDataBaseConfig(
         config.setPoolName(this.poolName);
         config.setInitializationFailTimeout(-1);
         config.setAutoCommit(true);
-
+        config.setSchema(this.schema);
 
         config.setDataSourceProperties(this.dsProperties);
 

--- a/database/database-jdbc/src/test/java/ru/tinkoff/kora/database/jdbc/JdbcDataBaseTest.java
+++ b/database/database-jdbc/src/test/java/ru/tinkoff/kora/database/jdbc/JdbcDataBaseTest.java
@@ -33,6 +33,7 @@ class JdbcDataBaseTest {
             params.password(),
             params.jdbcUrl(),
             "testPool",
+            null,
             1000L,
             1000L,
             1000L,


### PR DESCRIPTION
For Oracle database we can't set default schema via JDBC url. 
We can add it via HikariCP but property `schema` didn't add in `JdbcDataBaseConfig`