### PR TITLE
Ksp jdbc extension should not generate result set mappers for single object, but use util method

### DIFF
--- a/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/jdbc/JdbcExtensionTest.java
+++ b/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/jdbc/JdbcExtensionTest.java
@@ -1,9 +1,6 @@
 package ru.tinkoff.kora.database.common.annotation.processor.jdbc;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.mockito.Mockito;
 import ru.tinkoff.kora.annotation.processor.common.TestUtils;
 import ru.tinkoff.kora.application.graph.TypeRef;
 import ru.tinkoff.kora.database.common.annotation.processor.entity.TestEntityJavaBean;
@@ -15,67 +12,71 @@ import ru.tinkoff.kora.database.jdbc.mapper.result.JdbcRowMapper;
 import java.sql.ResultSet;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class JdbcExtensionTest {
-    public JdbcExtensionTest() throws Exception {}
+    @Test
+    void testTypes() throws Exception {
+        TestUtils.testKoraExtension(
+            new TypeRef<?>[]{
+                TypeRef.of(JdbcRowMapper.class, TestEntityRecord.class),
+                TypeRef.of(JdbcResultSetMapper.class, TestEntityRecord.class),
+                TypeRef.of(JdbcResultSetMapper.class, TypeRef.of(List.class, TestEntityRecord.class)),
+                TypeRef.of(JdbcRowMapper.class, TestEntityJavaBean.class),
+                TypeRef.of(JdbcResultSetMapper.class, TestEntityJavaBean.class),
+                TypeRef.of(JdbcResultSetMapper.class, TypeRef.of(List.class, TestEntityJavaBean.class)),
+                TypeRef.of(JdbcRowMapper.class, JdbcEntity.AllNativeTypesEntity.class),
+                TypeRef.of(JdbcResultSetMapper.class, TypeRef.of(List.class, JdbcEntity.AllNativeTypesEntity.class)),
+            },
+            TypeRef.of(JdbcResultColumnMapper.class, TestEntityRecord.UnknownTypeField.class),
+            TypeRef.of(JdbcEntity.TestEntityFieldJdbcResultColumnMapperNonFinal.class)
+        );
+    }
 
-    private final ClassLoader cl = TestUtils.testKoraExtension(
-        new TypeRef<?>[]{
-            TypeRef.of(JdbcRowMapper.class, TestEntityRecord.class),
-            TypeRef.of(JdbcResultSetMapper.class, TestEntityRecord.class),
-            TypeRef.of(JdbcResultSetMapper.class, TypeRef.of(List.class, TestEntityRecord.class)),
-            TypeRef.of(JdbcRowMapper.class, TestEntityJavaBean.class),
-            TypeRef.of(JdbcResultSetMapper.class, TestEntityJavaBean.class),
-            TypeRef.of(JdbcResultSetMapper.class, TypeRef.of(List.class, TestEntityJavaBean.class)),
-            TypeRef.of(JdbcRowMapper.class, JdbcEntity.AllNativeTypesEntity.class),
-            TypeRef.of(JdbcResultSetMapper.class, TypeRef.of(List.class, JdbcEntity.AllNativeTypesEntity.class)),
-        },
-        TypeRef.of(JdbcResultColumnMapper.class, TestEntityRecord.UnknownTypeField.class),
-        TypeRef.of(JdbcEntity.TestEntityFieldJdbcResultColumnMapperNonFinal.class)
-    );
-
+    public record TestRow(String f1, String f2) {}
 
     @Test
-    @SuppressWarnings("unchecked")
     void testRowMapper() throws Exception {
-        JdbcResultColumnMapper<TestEntityRecord.UnknownTypeField> unknownFieldMapper = Mockito.mock(JdbcResultColumnMapper.class);
-        var mappedField2Mapper = Mockito.mock(JdbcEntity.TestEntityFieldJdbcResultColumnMapperNonFinal.class);
-        var jdbcRowMapper = (JdbcRowMapper<TestEntityRecord>) cl.loadClass("ru.tinkoff.kora.database.common.annotation.processor.entity.$TestEntityRecord_JdbcRowMapper")
-            .getConstructor(JdbcResultColumnMapper.class, JdbcEntity.TestEntityFieldJdbcResultColumnMapperNonFinal.class)
-            .newInstance(unknownFieldMapper, mappedField2Mapper);
+        var cl = TestUtils.testKoraExtension(new TypeRef<?>[]{
+                TypeRef.of(JdbcResultSetMapper.class, TestRow.class),
+            }
+        );
+        var k = cl.loadClass("ru.tinkoff.kora.database.common.annotation.processor.jdbc.$JdbcExtensionTest_TestRow_JdbcRowMapper");
+        var mapper = (JdbcRowMapper<TestRow>) k.getConstructors()[0].newInstance();
+        var rs = mock(ResultSet.class);
 
-        var row = Mockito.mock(ResultSet.class);
-        var ref = TestEntityRecord.defaultRecord();
-        when(row.findColumn("field1")).thenReturn(1);
-        when(row.findColumn("field2")).thenReturn(2);
-        when(row.findColumn("field3")).thenReturn(3);
-        when(row.findColumn("unknown_type_field")).thenReturn(4);
-        when(row.findColumn("mapped_field1")).thenReturn(5);
-        when(row.findColumn("mapped_field2")).thenReturn(6);
+        when(rs.findColumn("f1")).thenReturn(1);
+        when(rs.findColumn("f2")).thenReturn(2);
+        when(rs.getString(1)).thenReturn("test1");
+        when(rs.getString(2)).thenReturn("test2");
+        var o1 = mapper.apply(rs);
+        assertThat(o1).isEqualTo(new TestRow("test1", "test2"));
+        verify(rs).getString(1);
+        verify(rs).getString(2);
+    }
 
-        when(row.wasNull()).thenReturn(false, false, false, false, false, false);
-        when(row.getString(1)).thenReturn(ref.field1());
-        when(row.getInt(2)).thenReturn(ref.field2());
-        when(row.getInt(3)).thenReturn(ref.field3());
-        when(unknownFieldMapper.apply(any(), eq(4))).thenReturn(new TestEntityRecord.UnknownTypeField());
-        when(mappedField2Mapper.apply(any(), eq(6))).thenReturn(new TestEntityRecord.MappedField2());
+    @Test
+    void testListResultSetMapper() throws Exception {
+        var cl = TestUtils.testKoraExtension(new TypeRef<?>[]{
+                TypeRef.of(JdbcResultSetMapper.class, TypeRef.of(List.class, TestRow.class)),
+            }
+        );
+        var k = cl.loadClass("ru.tinkoff.kora.database.common.annotation.processor.jdbc.$JdbcExtensionTest_TestRow_ListJdbcResultSetMapper");
+        var mapper = (JdbcResultSetMapper<List<TestRow>>) k.getConstructors()[0].newInstance();
+        var rs = mock(ResultSet.class);
 
-        var result = jdbcRowMapper.apply(row);
+        when(rs.next()).thenReturn(true, true, false);
+        when(rs.findColumn("f1")).thenReturn(1);
+        when(rs.findColumn("f2")).thenReturn(2);
+        when(rs.getString(1)).thenReturn("test1");
+        when(rs.getString(2)).thenReturn("test2");
 
-        verify(row).findColumn("field1");
-        verify(row).findColumn("field2");
-        verify(row).findColumn("field3");
-        verify(row).findColumn("unknown_type_field");
-        verify(row).findColumn("mapped_field1");
-        verify(row).findColumn("mapped_field2");
-        verify(unknownFieldMapper).apply(any(), eq(4));
-        verify(mappedField2Mapper).apply(any(), eq(6));
+        var o1 = mapper.apply(rs);
 
-        Assertions.assertThat(result).isEqualTo(ref);
+        assertThat(o1).isEqualTo(List.of(new TestRow("test1", "test2"), new TestRow("test1", "test2")));
+        verify(rs, times(2)).getString(1);
+        verify(rs, times(2)).getString(2);
+        verify(rs, times(3)).next();
     }
 }

--- a/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/jdbc/extension/JdbcTypesExtension.kt
+++ b/database/database-symbol-processor/src/main/kotlin/ru/tinkoff/kora/database/symbol/processor/jdbc/extension/JdbcTypesExtension.kt
@@ -1,10 +1,12 @@
 package ru.tinkoff.kora.database.symbol.processor.jdbc.extension
 
 import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.getFunctionDeclarationsByName
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.Variance
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.ksp.toTypeName
@@ -18,6 +20,7 @@ import ru.tinkoff.kora.kora.app.ksp.extension.KoraExtension
 import ru.tinkoff.kora.ksp.common.CommonClassNames.isList
 import ru.tinkoff.kora.ksp.common.KotlinPoetUtils.controlFlow
 import ru.tinkoff.kora.ksp.common.KspCommonUtils.generated
+import ru.tinkoff.kora.ksp.common.KspCommonUtils.parametrized
 import ru.tinkoff.kora.ksp.common.getOuterClassesAsPrefix
 
 // JdbcRowMapper<T>
@@ -52,62 +55,79 @@ class JdbcTypesExtension(val resolver: Resolver, val kspLogger: KSPLogger, val c
         }
         if (type.declaration.qualifiedName!!.asString() == JdbcTypes.jdbcResultSetMapper.canonicalName) {
             val resultType = type.arguments[0].type!!.resolve()
-            val rowType = if (resultType.isList()) resultType.arguments[0].type!!.resolve() else resultType
-            val entity = DbEntity.parseEntity(rowType) ?: return null
-            return this.entityResultSetMapper(resolver, entity, resultType)
+            if (resultType.isList()) {
+                val rowType = resultType.arguments[0].type!!.resolve()
+                val entity = DbEntity.parseEntity(rowType)
+                if (entity != null) {
+                    return this.entityListResultSetMapper(resolver, entity)
+                } else {
+                    return null
+                }
+            } else {
+                return {
+                    val resultSetMapperDecl = resolver.getClassDeclarationByName(JdbcTypes.jdbcResultSetMapper.canonicalName)!!
+                    val rowMapperDecl = resolver.getClassDeclarationByName(JdbcTypes.jdbcRowMapper.canonicalName)!!
+
+                    val resultSetMapperType = resultSetMapperDecl.asType(listOf(resolver.getTypeArgument(
+                        resolver.createKSTypeReferenceFromKSType(resultType), Variance.INVARIANT
+                    )))
+                    val rowMapperType = rowMapperDecl.asType(listOf(resolver.getTypeArgument(
+                        resolver.createKSTypeReferenceFromKSType(resultType), Variance.INVARIANT
+                    )))
+
+                    val functionDecl = resolver.getFunctionDeclarationsByName(JdbcTypes.jdbcResultSetMapper.canonicalName + ".singleResultSetMapper").first()
+                    val functionType = functionDecl.parametrized(resultSetMapperType, listOf(rowMapperType))
+                    ExtensionResult.fromExecutable(functionDecl, functionType)
+                }
+            }
         }
         return null
     }
 
-    private fun entityResultSetMapper(resolver: Resolver, entity: DbEntity, resultType: KSType): (() -> ExtensionResult)? {
-        val mapperName = entity.type.declaration.getOuterClassesAsPrefix() +
-            "${entity.type.declaration.simpleName.getShortName()}_Jdbc${if (resultType.isList()) "List" else ""}ResultSetMapper"
+    private fun entityListResultSetMapper(resolver: Resolver, entity: DbEntity): (() -> ExtensionResult)? {
+        val mapperName = entity.type.declaration.getOuterClassesAsPrefix() + "${entity.type.declaration.simpleName.getShortName()}_JdbcListResultSetMapper"
         val packageName = entity.type.declaration.packageName.asString()
-
         return lambda@{
             val maybeGenerated = resolver.getClassDeclarationByName("$packageName.$mapperName")
             if (maybeGenerated != null) {
-                val constructor = maybeGenerated.primaryConstructor ?: throw IllegalStateException()
+                val constructor = maybeGenerated.primaryConstructor
+                if (constructor == null) {
+                    throw IllegalStateException()
+                }
                 return@lambda ExtensionResult.fromConstructor(constructor, maybeGenerated)
             }
-
             val entityTypeName = entity.type.toTypeName()
-            val resultTypeName = if (resultType.isList()) {
-                List::class.asClassName().parameterizedBy(entityTypeName)
-            } else {
-                entityTypeName
-            }
+            val resultTypeName = List::class.asClassName().parameterizedBy(entityTypeName)
+            val type = TypeSpec.classBuilder(mapperName)
+                .generated(JdbcTypesExtension::class)
+                .addSuperinterface(JdbcTypes.jdbcResultSetMapper.parameterizedBy(resultTypeName))
 
             val constructor = FunSpec.constructorBuilder()
             val apply = FunSpec.builder("apply")
                 .addModifiers(KModifier.OVERRIDE)
                 .addParameter("_rs", JdbcTypes.resultSet)
                 .returns(resultTypeName)
-
-            val type = TypeSpec.classBuilder(mapperName)
-                .generated(JdbcTypesExtension::class)
-                .addSuperinterface(JdbcTypes.jdbcResultSetMapper.parameterizedBy(resultTypeName))
-
+            apply.controlFlow("if (!_rs.next())") {
+                addStatement("return listOf()")
+            }
             val read = this.entityReader.readEntity("_row", entity)
             read.enrich(type, constructor)
             apply.addCode(parseIndexes(entity, "_rs"))
+            apply.addStatement("val _result = ArrayList<%T>()", entityTypeName)
+            apply.addCode(CodeBlock.builder()
+                .add("do {").indent().add("\n")
+                .add(read.block)
+                .add("_result.add(_row)")
+                .unindent().add("\n} while(_rs.next())\n")
+                .build())
+            apply.addStatement("return _result")
 
-            if (resultType.isList()) {
-                apply.addStatement("val _result = ArrayList<%T>()", entityTypeName)
-                apply.controlFlow("while (_rs.next())") {
-                    addCode(read.block)
-                    addStatement("_result.add(_row)")
-                }
-                apply.addStatement("return _result")
-            } else {
-                apply.addCode(read.block)
-                apply.addStatement("return _row")
-            }
 
             type.primaryConstructor(constructor.build())
             type.addFunction(apply.build())
 
             FileSpec.get(packageName, type.build()).writeTo(codeGenerator, true, listOfNotNull(entity.type.declaration.containingFile))
+
             ExtensionResult.RequiresCompilingResult
         }
     }

--- a/database/database-symbol-processor/src/test/kotlin/ru/tinkoff/kora/database/symbol/processor/jdbc/JdbcExtensionTest.kt
+++ b/database/database-symbol-processor/src/test/kotlin/ru/tinkoff/kora/database/symbol/processor/jdbc/JdbcExtensionTest.kt
@@ -1,11 +1,14 @@
 package ru.tinkoff.kora.database.symbol.processor.jdbc
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
 import ru.tinkoff.kora.database.jdbc.mapper.result.JdbcResultColumnMapper
 import ru.tinkoff.kora.database.jdbc.mapper.result.JdbcResultSetMapper
 import ru.tinkoff.kora.database.jdbc.mapper.result.JdbcRowMapper
 import ru.tinkoff.kora.database.symbol.processor.entity.TestEntity
 import ru.tinkoff.kora.ksp.common.TestUtils
+import java.sql.ResultSet
 import kotlin.reflect.typeOf
 
 class JdbcExtensionTest {
@@ -23,5 +26,60 @@ class JdbcExtensionTest {
             typeOf<JdbcResultColumnMapper<TestEntity.UnknownField?>>(),
             typeOf<TestEntityFieldJdbcResultColumnMapperNonFinal>(),
         )
+    }
+
+    data class TestRow(val f1: String, val f2: String)
+
+    @Test
+    fun testRowMapper() {
+        val cl = TestUtils.testKoraExtension(
+            arrayOf(
+                typeOf<JdbcResultSetMapper<TestRow>>(),
+            )
+        )!!
+        val k = cl.loadClass("ru.tinkoff.kora.database.symbol.processor.jdbc.\$JdbcExtensionTest_TestRow_JdbcRowMapper")
+        val mapper = k.constructors[0].newInstance() as JdbcRowMapper<TestRow>
+        val rs = mock<ResultSet>()
+
+        whenever(rs.findColumn("f1")).thenReturn(1)
+        whenever(rs.findColumn("f2")).thenReturn(2)
+        whenever(rs.getString(1)).thenReturn("test1")
+        whenever(rs.getString(2)).thenReturn("test2")
+
+        val o1 = mapper.apply(rs)
+
+        assertThat(o1).isEqualTo(TestRow("test1", "test2"))
+        verify(rs).getString(1)
+        verify(rs).getString(2)
+    }
+
+    @Test
+    fun testListResultSetMapper() {
+        val cl = TestUtils.testKoraExtension(
+            arrayOf(
+                typeOf<JdbcResultSetMapper<List<TestRow>>>(),
+            )
+        )!!
+        val k = cl.loadClass("ru.tinkoff.kora.database.symbol.processor.jdbc.\$JdbcExtensionTest_TestRow_JdbcListResultSetMapper")
+        val mapper = k.constructors[0].newInstance() as JdbcResultSetMapper<List<TestRow>>
+        val rs = mock<ResultSet>()
+
+        whenever(rs.next()).thenReturn(true, true, false)
+        whenever(rs.findColumn("f1")).thenReturn(1)
+        whenever(rs.findColumn("f2")).thenReturn(2)
+        whenever(rs.getString(1)).thenReturn("test1")
+        whenever(rs.getString(2)).thenReturn("test2")
+        val o1 = mapper.apply(rs)
+        assertThat(o1).isEqualTo(listOf(TestRow("test1", "test2"), TestRow("test1", "test2")))
+        verify(rs, times(3)).next()
+        verify(rs, times(2)).getString(1)
+        verify(rs, times(2)).getString(2)
+        reset(rs)
+
+        whenever(rs.next()).thenReturn(false)
+        val o2 = mapper.apply(rs)
+        assertThat(o2).isEmpty()
+        verify(rs).next()
+        verifyNoMoreInteractions(rs)
     }
 }


### PR DESCRIPTION
Resolves #81