### PR TITLE
Jdk scheduling module now uses its own scheduler interface

### DIFF
--- a/scheduling/scheduling-annotation-processor/src/main/java/ru/tinkoff/kora/scheduling/annotation/processor/JdkSchedulingGenerator.java
+++ b/scheduling/scheduling-annotation-processor/src/main/java/ru/tinkoff/kora/scheduling/annotation/processor/JdkSchedulingGenerator.java
@@ -18,13 +18,13 @@ import javax.lang.model.util.Types;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.concurrent.ScheduledExecutorService;
 
 public class JdkSchedulingGenerator {
     private static final ClassName fixedDelayJobClassName = ClassName.get("ru.tinkoff.kora.scheduling.jdk", "FixedDelayJob");
     private static final ClassName fixedRateJobClassName = ClassName.get("ru.tinkoff.kora.scheduling.jdk", "FixedRateJob");
     private static final ClassName runOnceJobClassName = ClassName.get("ru.tinkoff.kora.scheduling.jdk", "RunOnceJob");
     private static final ClassName schedulingTelemetryFactoryClassName = ClassName.get("ru.tinkoff.kora.scheduling.common.telemetry", "SchedulingTelemetryFactory");
+    private static final ClassName jdkSchedulingExecutor = ClassName.get("ru.tinkoff.kora.scheduling.jdk", "JdkSchedulingExecutor");
     private final Elements elements;
     private final Types types;
     private final Messager messager;
@@ -72,7 +72,7 @@ public class JdkSchedulingGenerator {
         var componentMethod = MethodSpec.methodBuilder(jobMethodName)
             .addModifiers(Modifier.DEFAULT, Modifier.PUBLIC)
             .addParameter(schedulingTelemetryFactoryClassName, "telemetryFactory")
-            .addParameter(TypeName.get(ScheduledExecutorService.class), "service")
+            .addParameter(jdkSchedulingExecutor, "service")
             .addParameter(TypeName.get(type.asType()), "object")
             .returns(runOnceJobClassName)
             .addCode("var telemetry = telemetryFactory.get($T.class, $S);\n", type, method.getSimpleName());
@@ -116,7 +116,7 @@ public class JdkSchedulingGenerator {
         var componentMethod = MethodSpec.methodBuilder(jobMethodName)
             .addModifiers(Modifier.DEFAULT, Modifier.PUBLIC)
             .addParameter(schedulingTelemetryFactoryClassName, "telemetryFactory")
-            .addParameter(TypeName.get(ScheduledExecutorService.class), "service")
+            .addParameter(jdkSchedulingExecutor, "service")
             .addParameter(TypeName.get(type.asType()), "object")
             .returns(fixedDelayJobClassName)
             .addCode("var telemetry = telemetryFactory.get($T.class, $S);\n", type, method.getSimpleName());
@@ -167,7 +167,7 @@ public class JdkSchedulingGenerator {
         var componentMethod = MethodSpec.methodBuilder(jobMethodName)
             .addModifiers(Modifier.DEFAULT, Modifier.PUBLIC)
             .addParameter(schedulingTelemetryFactoryClassName, "telemetryFactory")
-            .addParameter(TypeName.get(ScheduledExecutorService.class), "service")
+            .addParameter(jdkSchedulingExecutor, "service")
             .addParameter(TypeName.get(type.asType()), "object")
             .returns(fixedRateJobClassName)
             .addCode("var telemetry = telemetryFactory.get($T.class, $S);\n", type, method.getSimpleName());

--- a/scheduling/scheduling-annotation-processor/src/test/java/ru/tinkoff/kora/scheduling/annotation/processor/KoraSchedulingAnnotationProcessorTest.java
+++ b/scheduling/scheduling-annotation-processor/src/test/java/ru/tinkoff/kora/scheduling/annotation/processor/KoraSchedulingAnnotationProcessorTest.java
@@ -6,11 +6,27 @@ import ru.tinkoff.kora.scheduling.annotation.processor.controller.*;
 
 class KoraSchedulingAnnotationProcessorTest {
     @Test
-    void test() throws Exception {
+    void testScheduledJdkAtFixedRateTest() throws Exception {
         process(ScheduledJdkAtFixedRateTest.class);
+    }
+
+    @Test
+    void testScheduledJdkAtFixedDelayTest() throws Exception {
         process(ScheduledJdkAtFixedDelayTest.class);
+    }
+
+    @Test
+    void testScheduledJdkOnceTest() throws Exception {
         process(ScheduledJdkOnceTest.class);
+    }
+
+    @Test
+    void testScheduledWithTrigger() throws Exception {
         process(ScheduledWithTrigger.class);
+    }
+
+    @Test
+    void testScheduledWithCron() throws Exception {
         process(ScheduledWithCron.class);
     }
 

--- a/scheduling/scheduling-annotation-processor/src/test/java/ru/tinkoff/kora/scheduling/annotation/processor/controller/ScheduledJdkAtFixedRateTest.java
+++ b/scheduling/scheduling-annotation-processor/src/test/java/ru/tinkoff/kora/scheduling/annotation/processor/controller/ScheduledJdkAtFixedRateTest.java
@@ -6,27 +6,17 @@ import java.time.temporal.ChronoUnit;
 
 public class ScheduledJdkAtFixedRateTest {
     @ScheduleAtFixedRate(initialDelay = 100, period = 1000, config = "baseline", unit = ChronoUnit.MILLIS)
-    public void baseline() {
-
-    }
+    public void baseline() {}
 
     @ScheduleAtFixedRate(initialDelay = 100, period = 1000, unit = ChronoUnit.MILLIS)
-    public void noConfig() {
-
-    }
+    public void noConfig() {}
 
     @ScheduleAtFixedRate(config = "onlyConfig")
-    public void onlyConfig() {
-
-    }
+    public void onlyConfig() {}
 
     @ScheduleAtFixedRate(period = 1000)
-    public void onlyRequired() {
-
-    }
+    public void onlyRequired() {}
 
     @ScheduleAtFixedRate(period = 1000, config = "onlyRequiredWithConfig")
-    public void onlyRequiredWithConfig() {
-
-    }
+    public void onlyRequiredWithConfig() {}
 }

--- a/scheduling/scheduling-jdk/src/main/java/ru/tinkoff/kora/scheduling/jdk/AbstractJob.java
+++ b/scheduling/scheduling-jdk/src/main/java/ru/tinkoff/kora/scheduling/jdk/AbstractJob.java
@@ -6,18 +6,17 @@ import ru.tinkoff.kora.application.graph.Lifecycle;
 import ru.tinkoff.kora.common.Context;
 import ru.tinkoff.kora.scheduling.common.telemetry.SchedulingTelemetry;
 
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public abstract class AbstractJob implements Lifecycle {
     private final SchedulingTelemetry telemetry;
-    private final ScheduledExecutorService service;
+    private final JdkSchedulingExecutor service;
     private final Runnable command;
     private final AtomicBoolean started = new AtomicBoolean(false);
     private volatile ScheduledFuture<?> scheduledFuture;
 
-    public AbstractJob(SchedulingTelemetry telemetry, ScheduledExecutorService service, Runnable command) {
+    public AbstractJob(SchedulingTelemetry telemetry, JdkSchedulingExecutor service, Runnable command) {
         this.telemetry = telemetry;
         this.service = service;
         this.command = command;
@@ -45,7 +44,7 @@ public abstract class AbstractJob implements Lifecycle {
         }
     }
 
-    protected abstract ScheduledFuture<?> schedule(ScheduledExecutorService service, Runnable command);
+    protected abstract ScheduledFuture<?> schedule(JdkSchedulingExecutor service, Runnable command);
 
     @Override
     public final Mono<?> release() {

--- a/scheduling/scheduling-jdk/src/main/java/ru/tinkoff/kora/scheduling/jdk/DefaultJdkSchedulingExecutor.java
+++ b/scheduling/scheduling-jdk/src/main/java/ru/tinkoff/kora/scheduling/jdk/DefaultJdkSchedulingExecutor.java
@@ -2,18 +2,18 @@ package ru.tinkoff.kora.scheduling.jdk;
 
 import reactor.core.publisher.Mono;
 import ru.tinkoff.kora.application.graph.Lifecycle;
-import ru.tinkoff.kora.application.graph.Wrapped;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class ScheduledExecutorServiceLifecycle implements Lifecycle, Wrapped<ScheduledExecutorService> {
+public class DefaultJdkSchedulingExecutor implements Lifecycle, JdkSchedulingExecutor {
     private final ScheduledExecutorServiceConfig config;
     private volatile ScheduledExecutorService service;
 
-    public ScheduledExecutorServiceLifecycle(ScheduledExecutorServiceConfig config) {
+    public DefaultJdkSchedulingExecutor(ScheduledExecutorServiceConfig config) {
         this.config = config;
     }
 
@@ -43,7 +43,17 @@ public class ScheduledExecutorServiceLifecycle implements Lifecycle, Wrapped<Sch
     }
 
     @Override
-    public ScheduledExecutorService value() {
-        return this.service;
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit milliseconds) {
+        return this.service.scheduleWithFixedDelay(command, initialDelay, delay, milliseconds);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelayMillis, long periodMillis, TimeUnit milliseconds) {
+        return this.service.scheduleAtFixedRate(command, initialDelayMillis, periodMillis, milliseconds);
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit timeUnit) {
+        return this.service.schedule(command, delay, timeUnit);
     }
 }

--- a/scheduling/scheduling-jdk/src/main/java/ru/tinkoff/kora/scheduling/jdk/FixedDelayJob.java
+++ b/scheduling/scheduling-jdk/src/main/java/ru/tinkoff/kora/scheduling/jdk/FixedDelayJob.java
@@ -4,7 +4,6 @@ import ru.tinkoff.kora.scheduling.common.telemetry.SchedulingTelemetry;
 
 import java.time.Duration;
 import java.util.Objects;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -12,14 +11,14 @@ public final class FixedDelayJob extends AbstractJob {
     private final Duration initialDelay;
     private final Duration delay;
 
-    public FixedDelayJob(SchedulingTelemetry schedulingTelemetry, ScheduledExecutorService service, Runnable command, Duration initialDelay, Duration delay) {
+    public FixedDelayJob(SchedulingTelemetry schedulingTelemetry, JdkSchedulingExecutor service, Runnable command, Duration initialDelay, Duration delay) {
         super(schedulingTelemetry, service, command);
         this.initialDelay = Objects.requireNonNull(initialDelay);
         this.delay = Objects.requireNonNull(delay);
     }
 
     @Override
-    protected ScheduledFuture<?> schedule(ScheduledExecutorService service, Runnable command) {
+    protected ScheduledFuture<?> schedule(JdkSchedulingExecutor service, Runnable command) {
         var initialDelay = this.initialDelay.toMillis();
         var delay = this.delay.toMillis();
         return service.scheduleWithFixedDelay(command, initialDelay, delay, TimeUnit.MILLISECONDS);

--- a/scheduling/scheduling-jdk/src/main/java/ru/tinkoff/kora/scheduling/jdk/FixedRateJob.java
+++ b/scheduling/scheduling-jdk/src/main/java/ru/tinkoff/kora/scheduling/jdk/FixedRateJob.java
@@ -4,7 +4,6 @@ import ru.tinkoff.kora.scheduling.common.telemetry.SchedulingTelemetry;
 
 import java.time.Duration;
 import java.util.Objects;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -12,14 +11,14 @@ public final class FixedRateJob extends AbstractJob {
     private final Duration initialDelay;
     private final Duration period;
 
-    public FixedRateJob(SchedulingTelemetry schedulingTelemetry, ScheduledExecutorService service, Runnable command, Duration initialDelay, Duration period) {
+    public FixedRateJob(SchedulingTelemetry schedulingTelemetry, JdkSchedulingExecutor service, Runnable command, Duration initialDelay, Duration period) {
         super(schedulingTelemetry, service, command);
         this.initialDelay = Objects.requireNonNull(initialDelay);
         this.period = Objects.requireNonNull(period);
     }
 
     @Override
-    protected ScheduledFuture<?> schedule(ScheduledExecutorService service, Runnable command) {
+    protected ScheduledFuture<?> schedule(JdkSchedulingExecutor service, Runnable command) {
         var initialDelayMillis = this.initialDelay.toMillis();
         var periodMillis = this.period.toMillis();
         return service.scheduleAtFixedRate(command, initialDelayMillis, periodMillis, TimeUnit.MILLISECONDS);

--- a/scheduling/scheduling-jdk/src/main/java/ru/tinkoff/kora/scheduling/jdk/JdkSchedulingExecutor.java
+++ b/scheduling/scheduling-jdk/src/main/java/ru/tinkoff/kora/scheduling/jdk/JdkSchedulingExecutor.java
@@ -1,0 +1,23 @@
+package ru.tinkoff.kora.scheduling.jdk;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+public interface JdkSchedulingExecutor {
+
+    /**
+     * @see java.util.concurrent.ScheduledExecutorService#scheduleWithFixedDelay(Runnable, long, long, TimeUnit)
+     */
+    ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit timeUnit);
+
+    /**
+     * @see java.util.concurrent.ScheduledExecutorService#scheduleAtFixedRate(Runnable, long, long, TimeUnit)
+     */
+    ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelayMillis, long periodMillis, TimeUnit timeUnit);
+
+
+    /**
+     * @see java.util.concurrent.ScheduledExecutorService#schedule(Runnable, long, TimeUnit)
+     */
+    ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit timeUnit);
+}

--- a/scheduling/scheduling-jdk/src/main/java/ru/tinkoff/kora/scheduling/jdk/RunOnceJob.java
+++ b/scheduling/scheduling-jdk/src/main/java/ru/tinkoff/kora/scheduling/jdk/RunOnceJob.java
@@ -4,20 +4,19 @@ import ru.tinkoff.kora.scheduling.common.telemetry.SchedulingTelemetry;
 
 import java.time.Duration;
 import java.util.Objects;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 public final class RunOnceJob extends AbstractJob {
     private final Duration delay;
 
-    public RunOnceJob(SchedulingTelemetry schedulingTelemetry, ScheduledExecutorService service, Runnable command, Duration delay) {
+    public RunOnceJob(SchedulingTelemetry schedulingTelemetry, JdkSchedulingExecutor service, Runnable command, Duration delay) {
         super(schedulingTelemetry, service, command);
         this.delay = Objects.requireNonNull(delay);
     }
 
     @Override
-    protected ScheduledFuture<?> schedule(ScheduledExecutorService service, Runnable command) {
+    protected ScheduledFuture<?> schedule(JdkSchedulingExecutor service, Runnable command) {
         var delay = this.delay.toMillis();
         return service.schedule(command, delay, TimeUnit.MILLISECONDS);
     }

--- a/scheduling/scheduling-jdk/src/main/java/ru/tinkoff/kora/scheduling/jdk/SchedulingJdkModule.java
+++ b/scheduling/scheduling-jdk/src/main/java/ru/tinkoff/kora/scheduling/jdk/SchedulingJdkModule.java
@@ -2,6 +2,7 @@ package ru.tinkoff.kora.scheduling.jdk;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValueFactory;
+import ru.tinkoff.kora.common.DefaultComponent;
 import ru.tinkoff.kora.config.common.extractor.ConfigValueExtractor;
 import ru.tinkoff.kora.scheduling.common.SchedulingModule;
 
@@ -16,7 +17,8 @@ public interface SchedulingJdkModule extends SchedulingModule {
         }
     }
 
-    default ScheduledExecutorServiceLifecycle scheduledExecutorServiceLifecycle(ScheduledExecutorServiceConfig config) {
-        return new ScheduledExecutorServiceLifecycle(config);
+    @DefaultComponent
+    default JdkSchedulingExecutor scheduledExecutorServiceLifecycle(ScheduledExecutorServiceConfig config) {
+        return new DefaultJdkSchedulingExecutor(config);
     }
 }

--- a/scheduling/scheduling-ksp/src/main/kotlin/ru/tinkoff/kora/scheduling/ksp/JdkSchedulingGenerator.kt
+++ b/scheduling/scheduling-ksp/src/main/kotlin/ru/tinkoff/kora/scheduling/ksp/JdkSchedulingGenerator.kt
@@ -13,12 +13,12 @@ import ru.tinkoff.kora.ksp.common.KspCommonUtils.generated
 import ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException
 import ru.tinkoff.kora.ksp.common.getOuterClassesAsPrefix
 import java.time.Duration
-import java.util.concurrent.ScheduledExecutorService
 
 class JdkSchedulingGenerator(val environment: SymbolProcessorEnvironment) {
     private val fixedDelayJobClassName = ClassName("ru.tinkoff.kora.scheduling.jdk", "FixedDelayJob")
     private val fixedRateJobClassName = ClassName("ru.tinkoff.kora.scheduling.jdk", "FixedRateJob")
     private val runOnceJobClassName = ClassName("ru.tinkoff.kora.scheduling.jdk", "RunOnceJob")
+    private val jdkSchedulingExecutor = ClassName("ru.tinkoff.kora.scheduling.jdk", "JdkSchedulingExecutor")
     private val schedulingTelemetryFactoryClassName = ClassName("ru.tinkoff.kora.scheduling.common.telemetry", "SchedulingTelemetryFactory")
 
     fun generate(type: KSClassDeclaration, function: KSFunctionDeclaration, builder: TypeSpec.Builder, trigger: SchedulingTrigger) {
@@ -40,7 +40,7 @@ class JdkSchedulingGenerator(val environment: SymbolProcessorEnvironment) {
         val unit = trigger.annotation.findValue<KSType>("unit")!!.toClassName()
         val componentFunction = FunSpec.builder(jobFunName)
             .addParameter("telemetryFactory", schedulingTelemetryFactoryClassName)
-            .addParameter("service", ScheduledExecutorService::class.asClassName())
+            .addParameter("service", jdkSchedulingExecutor)
             .addParameter("target", typeClassName)
             .returns(fixedRateJobClassName)
             .addCode("val telemetry = telemetryFactory.get(%T::class.java, %S);\n", typeClassName, function.simpleName.getShortName())
@@ -81,7 +81,7 @@ class JdkSchedulingGenerator(val environment: SymbolProcessorEnvironment) {
         val unit = trigger.annotation.findValue<KSType>("unit")!!.toClassName()
         val componentFunction = FunSpec.builder(jobFunName)
             .addParameter("telemetryFactory", schedulingTelemetryFactoryClassName)
-            .addParameter("service", ScheduledExecutorService::class.asClassName())
+            .addParameter("service", jdkSchedulingExecutor)
             .addParameter("target", typeClassName)
             .returns(fixedDelayJobClassName)
             .addCode("val telemetry = telemetryFactory.get(%T::class.java, %S);\n", typeClassName, function.simpleName.getShortName())
@@ -121,7 +121,7 @@ class JdkSchedulingGenerator(val environment: SymbolProcessorEnvironment) {
         val unit = trigger.annotation.findValue<KSType>("unit")!!.toClassName()
         val componentFunction = FunSpec.builder(jobFunName)
             .addParameter("telemetryFactory", schedulingTelemetryFactoryClassName)
-            .addParameter("service", ScheduledExecutorService::class.asClassName())
+            .addParameter("service", jdkSchedulingExecutor)
             .addParameter("target", typeClassName)
             .returns(runOnceJobClassName)
             .addCode("val telemetry = telemetryFactory.get(%T::class.java, %S);\n", typeClassName, function.simpleName.getShortName())

--- a/scheduling/scheduling-ksp/src/test/kotlin/ru/tinkoff/kora/scheduling/ksp/SchedulingKspTest.kt
+++ b/scheduling/scheduling-ksp/src/test/kotlin/ru/tinkoff/kora/scheduling/ksp/SchedulingKspTest.kt
@@ -8,16 +8,31 @@ import kotlin.reflect.KClass
 
 internal class SchedulingKspTest {
     @Test
-    internal fun test() {
+    internal fun testScheduledJdkAtFixedDelayTest() {
         process(ScheduledJdkAtFixedDelayTest::class)
+    }
+
+    @Test
+    internal fun testScheduledJdkAtFixedRateTest() {
         process(ScheduledJdkAtFixedRateTest::class)
+    }
+
+    @Test
+    internal fun testScheduledJdkOnceTest() {
         process(ScheduledJdkOnceTest::class)
+    }
+
+    @Test
+    internal fun testScheduledWithCron() {
         process(ScheduledWithCron::class)
+    }
+
+    @Test
+    internal fun testScheduledWithTrigger() {
         process(ScheduledWithTrigger::class)
     }
 
-    @Throws(Exception::class)
-    fun <T : Any> process(type: KClass<T>) {
+    private fun <T : Any> process(type: KClass<T>) {
         val cl = symbolProcess(type, SchedulingKspProvider())
 
         val module = cl.loadClass(type.asClassName().packageName + ".$" + type.simpleName + "_SchedulingModule")


### PR DESCRIPTION
So it will not interfere with other components implementing `ExecutorService`