### PR TITLE
Excluded static fields from jdbc mapping

### DIFF
--- a/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/entity/DbEntity.java
+++ b/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/entity/DbEntity.java
@@ -40,6 +40,7 @@ public record DbEntity(TypeMirror typeMirror, TypeElement typeElement, EntityTyp
         var nameConverter = CommonUtils.getNameConverter(typeElement);
         var fields = typeElement.getEnclosedElements().stream()
             .filter(e -> e.getKind() == ElementKind.FIELD)
+            .filter(DbEntity::isNotStaticField)
             .map(e -> {
                 var element = (VariableElement) e;
                 var type = element.asType();
@@ -70,6 +71,7 @@ public record DbEntity(TypeMirror typeMirror, TypeElement typeElement, EntityTyp
         var fields = typeElement.getEnclosedElements()
             .stream()
             .filter(e -> e.getKind() == ElementKind.FIELD)
+            .filter(DbEntity::isNotStaticField)
             .map(VariableElement.class::cast)
             .<DbEntity.EntityField>mapMulti((field, sink) -> {
                 var fieldType = field.asType();
@@ -101,6 +103,10 @@ public record DbEntity(TypeMirror typeMirror, TypeElement typeElement, EntityTyp
             return null;
         }
         return new DbEntity(typeMirror, typeElement, EntityType.BEAN, fields);
+    }
+
+    private static boolean isNotStaticField(Element element) {
+        return !element.getModifiers().contains(Modifier.STATIC);
     }
 
 }

--- a/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/entity/TestEntityJavaBean.java
+++ b/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/entity/TestEntityJavaBean.java
@@ -7,6 +7,8 @@ import ru.tinkoff.kora.database.common.annotation.processor.r2dbc.R2dbcEntity;
 import ru.tinkoff.kora.database.common.annotation.processor.vertx.VertxEntity;
 
 import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
 
 public class TestEntityJavaBean {
     private String field1;
@@ -32,6 +34,8 @@ public class TestEntityJavaBean {
     @Mapping(VertxEntity.TestEntityFieldVertxResultColumnMapperNonFinal.class)
     @Mapping(VertxEntity.TestEntityFieldVertxParameterColumnMapperNonFinal.class)
     private TestEntityRecord.MappedField2 mappedField2;
+
+    public static final Map<String, String> initializedStaticField = new HashMap<>();
 
     public static TestEntityJavaBean defaultJavaBean() {
         var v = new TestEntityJavaBean();

--- a/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/entity/TestEntityRecord.java
+++ b/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/entity/TestEntityRecord.java
@@ -9,6 +9,8 @@ import ru.tinkoff.kora.database.common.annotation.processor.r2dbc.R2dbcEntity;
 import ru.tinkoff.kora.database.common.annotation.processor.vertx.VertxEntity;
 
 import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
 
 @NamingStrategy(SnakeCaseNameConverter.class)
 public record TestEntityRecord(
@@ -36,6 +38,8 @@ public record TestEntityRecord(
     @Mapping(VertxEntity.TestEntityFieldVertxParameterColumnMapperNonFinal.class)
     MappedField2 mappedField2
 ) {
+
+    public static final Map<String, String> initializedStaticField = new HashMap<>();
 
     public record UnknownTypeField() {}
     public record MappedField1() {}


### PR DESCRIPTION
When using static fields in JDBC entities, the framework tries to make a mapper for them. 
It seems to be correct to exclude static fields from generation of DbEntity