### PR TITLE
fix: syntax error in kafka docs

### DIFF
--- a/mkdocs/docs/features/kafka.md
+++ b/mkdocs/docs/features/kafka.md
@@ -3,7 +3,7 @@
 ## Подключение
 
 ```groovy
-implemenation 'ru.tinkoff.kora:kafka'
+implementation 'ru.tinkoff.kora:kafka'
 ```
 
 ## Контейнер для KafkaConsumer


### PR DESCRIPTION
Fixed a syntax error in the word "implementation" in kafka docs