### PR TITLE
@Json nullable serialization support

### DIFF
--- a/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/CommonUtils.java
+++ b/annotation-processor-common/src/main/java/ru/tinkoff/kora/annotation/processor/common/CommonUtils.java
@@ -15,6 +15,7 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -504,9 +505,72 @@ public class CommonUtils {
     }
 
     public static boolean isList(TypeMirror type) {
+        if (type.getKind() != TypeKind.DECLARED) {
+            return false;
+        }
+        if (!(type instanceof DeclaredType dt)) {
+            return false;
+        }
+        var name = dt.asElement().toString();
+        return name.equals(List.class.getCanonicalName())
+            || name.equals(ArrayList.class.getCanonicalName())
+            || name.equals(LinkedList.class.getCanonicalName());
+    }
+
+    public static boolean isSet(TypeMirror type) {
+        if (type.getKind() != TypeKind.DECLARED) {
+            return false;
+        }
+        if (!(type instanceof DeclaredType dt)) {
+            return false;
+        }
+        var name = dt.asElement().toString();
+        return name.equals(Set.class.getCanonicalName())
+            || name.equals(HashSet.class.getCanonicalName())
+            || name.equals(TreeSet.class.getCanonicalName())
+            || name.equals(SortedSet.class.getCanonicalName())
+            || name.equals(LinkedHashSet.class.getCanonicalName())
+            || name.equals(CopyOnWriteArraySet.class.getCanonicalName())
+            || name.equals(ConcurrentSkipListSet.class.getCanonicalName());
+    }
+
+    public static boolean isQueue(TypeMirror type) {
         return type.getKind() == TypeKind.DECLARED
             && type instanceof DeclaredType dt
-            && dt.asElement().toString().equals("java.util.List");
+            && (dt.asElement().toString().equals(Queue.class.getCanonicalName())
+            || dt.asElement().toString().equals(Deque.class.getCanonicalName()));
+    }
+
+    public static boolean isCollection(TypeMirror type) {
+        return type.getKind() == TypeKind.DECLARED
+            && type instanceof DeclaredType dt
+            && (dt.asElement().toString().equals(Collection.class.getCanonicalName())
+            || isList(type)
+            || isSet(type)
+            || isQueue(type));
+    }
+
+    public static boolean isMap(TypeMirror type) {
+        if (type.getKind() != TypeKind.DECLARED) {
+            return false;
+        }
+        if (!(type instanceof DeclaredType dt)) {
+            return false;
+        }
+        var name = dt.asElement().toString();
+
+        return name.equals(Map.class.getCanonicalName())
+            || name.equals(HashMap.class.getCanonicalName())
+            || name.equals(TreeMap.class.getCanonicalName())
+            || name.equals(LinkedHashMap.class.getCanonicalName())
+            || name.equals(ConcurrentMap.class.getCanonicalName())
+            || name.equals(ConcurrentHashMap.class.getCanonicalName())
+            || name.equals(SortedMap.class.getCanonicalName())
+            || name.equals(NavigableMap.class.getCanonicalName())
+            || name.equals(ConcurrentSkipListMap.class.getCanonicalName())
+            || name.equals(IdentityHashMap.class.getCanonicalName())
+            || name.equals(WeakHashMap.class.getCanonicalName())
+            || name.equals(EnumMap.class.getCanonicalName());
     }
 
     public static boolean isOptional(TypeMirror type) {

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/JsonTypes.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/JsonTypes.java
@@ -4,6 +4,7 @@ import com.squareup.javapoet.ClassName;
 
 public class JsonTypes {
     public static final ClassName json = ClassName.get("ru.tinkoff.kora.json.common.annotation", "Json");
+    public static final ClassName jsonInclude = ClassName.get("ru.tinkoff.kora.json.common.annotation", "JsonInclude");
     public static final ClassName jsonDiscriminatorField = ClassName.get("ru.tinkoff.kora.json.common.annotation", "JsonDiscriminatorField");
     public static final ClassName jsonDiscriminatorValue = ClassName.get("ru.tinkoff.kora.json.common.annotation", "JsonDiscriminatorValue");
 

--- a/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/writer/JsonClassWriterMeta.java
+++ b/json/json-annotation-processor/src/main/java/ru/tinkoff/kora/json/annotation/processor/writer/JsonClassWriterMeta.java
@@ -6,14 +6,34 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 import java.util.List;
+import java.util.Optional;
 
 public record JsonClassWriterMeta(TypeMirror typeMirror, TypeElement typeElement, List<FieldMeta> fields) {
+
+    enum IncludeType {
+        ALWAYS,
+        NON_NULL,
+        NON_EMPTY;
+
+        private static final IncludeType[] types = values();
+
+        public static Optional<IncludeType> tryParse(String name) {
+            for (IncludeType includeType : types) {
+                if(includeType.name().equals(name)) {
+                    return Optional.of(includeType);
+                }
+            }
+
+            return Optional.empty();
+        }
+    }
 
     record FieldMeta(
         VariableElement field,
         TypeMirror typeMirror,
         WriterFieldType writerTypeMeta,
         String jsonName,
+        IncludeType includeType,
         ExecutableElement accessor,
         @Nullable TypeMirror writer
     ) {}

--- a/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/JsonIncludeTest.java
+++ b/json/json-annotation-processor/src/test/java/ru/tinkoff/kora/json/annotation/processor/JsonIncludeTest.java
@@ -1,0 +1,101 @@
+package ru.tinkoff.kora.json.annotation.processor;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import org.junit.jupiter.api.Test;
+import ru.tinkoff.kora.json.common.ListJsonReader;
+import ru.tinkoff.kora.json.common.ListJsonWriter;
+
+import java.util.List;
+
+public class JsonIncludeTest extends AbstractJsonAnnotationProcessorTest {
+    @Test
+    public void testIncludeAlways() {
+        compile("""
+            import ru.tinkoff.kora.json.common.annotation.JsonInclude;
+                            
+            @JsonInclude(JsonInclude.IncludeType.ALWAYS)
+            @Json
+            public record TestRecord(@Nullable Integer value) { }
+            """
+        );
+
+        compileResult.assertSuccess();
+
+        var mapper = mapper("TestRecord");
+        mapper.verifyWrite(newObject("TestRecord", 42), "{\"value\":42}");
+        mapper.verifyWrite(newObject("TestRecord", new Object[]{null}), "{\"value\":null}");
+    }
+
+    @Test
+    public void testIncludeNonNull() {
+        compile("""
+            import ru.tinkoff.kora.json.common.annotation.JsonInclude;
+                            
+            @JsonInclude(JsonInclude.IncludeType.NON_NULL)
+            @Json
+            public record TestRecord(@Nullable Integer value) { }
+            """
+        );
+
+        compileResult.assertSuccess();
+
+        var mapper = mapper("TestRecord");
+        mapper.verifyWrite(newObject("TestRecord", 42), "{\"value\":42}");
+        mapper.verifyWrite(newObject("TestRecord", new Object[]{null}), "{}");
+    }
+
+    @Test
+    public void testIncludeNonEmpty() {
+        compile("""
+            import ru.tinkoff.kora.json.common.annotation.JsonInclude;
+                            
+            @JsonInclude(JsonInclude.IncludeType.NON_EMPTY)
+            @Json
+            public record TestRecord(@Nullable java.util.List<Integer> value) { }
+            """
+        );
+
+        compileResult.assertSuccess();
+
+        var mapper = mapper("TestRecord", List.of(new ListJsonReader<>(JsonParser::getIntValue)), List.of(new ListJsonWriter<Integer>(JsonGenerator::writeNumber)));
+        mapper.verifyWrite(newObject("TestRecord", List.of(42)), "{\"value\":[42]}");
+        mapper.verifyWrite(newObject("TestRecord", List.of()), "{}");
+        mapper.verifyWrite(newObject("TestRecord", new Object[]{null}), "{}");
+    }
+
+    @Test
+    public void testFieldIncludeAlways() {
+        compile("""
+            import ru.tinkoff.kora.json.common.annotation.JsonInclude;
+                            
+            @Json
+            public record TestRecord(@Nullable String name, @JsonInclude(JsonInclude.IncludeType.ALWAYS) @Nullable Integer value) { }
+            """
+        );
+
+        compileResult.assertSuccess();
+
+        var mapper = mapper("TestRecord");
+        mapper.verifyWrite(newObject("TestRecord", "test", 42), "{\"name\":\"test\",\"value\":42}");
+        mapper.verifyWrite(newObject("TestRecord", null, null), "{\"value\":null}");
+    }
+
+    @Test
+    public void testFieldIncludeNonEmpty() {
+        compile("""
+            import ru.tinkoff.kora.json.common.annotation.JsonInclude;
+                            
+            @Json
+            public record TestRecord(@JsonInclude(JsonInclude.IncludeType.NON_EMPTY) @Nullable java.util.List<Integer> value) { }
+            """
+        );
+
+        compileResult.assertSuccess();
+
+        var mapper = mapper("TestRecord", List.of(new ListJsonReader<>(JsonParser::getIntValue)), List.of(new ListJsonWriter<Integer>(JsonGenerator::writeNumber)));
+        mapper.verifyWrite(newObject("TestRecord", List.of(42)), "{\"value\":[42]}");
+        mapper.verifyWrite(newObject("TestRecord", List.of()), "{}");
+        mapper.verifyWrite(newObject("TestRecord", new Object[]{null}), "{}");
+    }
+}

--- a/json/json-common/src/main/java/ru/tinkoff/kora/json/common/annotation/Json.java
+++ b/json/json-common/src/main/java/ru/tinkoff/kora/json/common/annotation/Json.java
@@ -14,4 +14,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Tag(Json.class)
 public @interface Json {
+
 }

--- a/json/json-common/src/main/java/ru/tinkoff/kora/json/common/annotation/JsonInclude.java
+++ b/json/json-common/src/main/java/ru/tinkoff/kora/json/common/annotation/JsonInclude.java
@@ -1,0 +1,44 @@
+package ru.tinkoff.kora.json.common.annotation;
+
+import ru.tinkoff.kora.common.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates which attribute value should be allowed for serialization
+ */
+@Target({ElementType.TYPE, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(JsonInclude.class)
+public @interface JsonInclude {
+
+    enum IncludeType {
+
+        /**
+         * Value that indicates that property is to be always included
+         */
+        ALWAYS,
+
+        /**
+         * Value that indicates that only properties with non-null values are to be included.
+         */
+        NON_NULL,
+
+        /**
+         * Value that indicates that only properties with null value,
+         * or what is considered empty, are not to be included.
+         * <p>
+         * Note: Can be applied ONLY to when it is possible to check {@link java.util.Collection} or {@link java.util.Map} type in compile time
+         * If type is generic this check can't be applied
+         */
+        NON_EMPTY
+    }
+
+    /**
+     * @return which value types to include when serializing
+     */
+    IncludeType value() default IncludeType.NON_NULL;
+}

--- a/json/json-common/src/main/java/ru/tinkoff/kora/json/common/annotation/JsonSkip.java
+++ b/json/json-common/src/main/java/ru/tinkoff/kora/json/common/annotation/JsonSkip.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates that annotated field will be skipped when serialized into JSON
+ * Indicates that annotated field will be ignored and not serialized into JSON
  */
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.CLASS)

--- a/json/json-common/src/main/java/ru/tinkoff/kora/json/common/annotation/JsonWriter.java
+++ b/json/json-common/src/main/java/ru/tinkoff/kora/json/common/annotation/JsonWriter.java
@@ -11,4 +11,5 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface JsonWriter {
+
 }

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/JsonProcessor.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/JsonProcessor.kt
@@ -55,18 +55,18 @@ class JsonProcessor(
         fileSpec.build().writeTo(codeGenerator = codeGenerator, aggregating = false)
     }
 
-    fun generateWriter(jsonClassDeclaration: KSClassDeclaration) {
-        val packageElement = jsonClassPackage(jsonClassDeclaration)
-        val writerClassName = jsonClassDeclaration.jsonWriterName()
+    fun generateWriter(declaration: KSClassDeclaration) {
+        val packageElement = jsonClassPackage(declaration)
+        val writerClassName = declaration.jsonWriterName()
         val writerDeclaration = resolver.getClassDeclarationByName("$packageElement.$writerClassName")
         if (writerDeclaration != null) {
             return
         }
         val writerType = when {
-            isSealed(jsonClassDeclaration) -> sealedWriterGenerator.generateSealedWriter(jsonClassDeclaration)
-            jsonClassDeclaration.modifiers.contains(Modifier.ENUM) -> enumJsonWriterGenerator.generateEnumWriter(jsonClassDeclaration)
+            isSealed(declaration) -> sealedWriterGenerator.generateSealedWriter(declaration)
+            declaration.modifiers.contains(Modifier.ENUM) -> enumJsonWriterGenerator.generateEnumWriter(declaration)
             else -> {
-                val meta = writerTypeMetaParser.parse(jsonClassDeclaration)
+                val meta = writerTypeMetaParser.parse(declaration)
                 writerGenerator.generate(meta)
             }
         }

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/JsonSymbolProcessor.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/JsonSymbolProcessor.kt
@@ -37,7 +37,6 @@ class JsonSymbolProcessor(
             try {
                 when (it) {
                     is KSClassDeclaration -> {
-
                         if (it.isAnnotationPresent(JsonTypes.json) || (it.isAnnotationPresent(JsonTypes.jsonReaderAnnotation) && it.isAnnotationPresent(JsonTypes.jsonWriterAnnotation))) {
                             if (processedReaders.add(it.qualifiedName!!.asString())) {
                                 jsonProcessor.generateReader(it)

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/JsonTypes.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/JsonTypes.kt
@@ -5,6 +5,7 @@ import com.squareup.kotlinpoet.ClassName
 object JsonTypes {
 
     val json = ClassName("ru.tinkoff.kora.json.common.annotation", "Json")
+    val jsonInclude = ClassName("ru.tinkoff.kora.json.common.annotation", "JsonInclude")
     val jsonDiscriminatorField = ClassName("ru.tinkoff.kora.json.common.annotation", "JsonDiscriminatorField")
     val jsonDiscriminatorValue = ClassName("ru.tinkoff.kora.json.common.annotation", "JsonDiscriminatorValue")
 

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/KnownType.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/KnownType.kt
@@ -35,7 +35,7 @@ class KnownType(private val resolver: Resolver) {
             float, nullableFloat -> KnownTypesEnum.FLOAT
             short, nullableShort -> KnownTypesEnum.SHORT
             bigInteger, bigInteger.makeNullable() -> KnownTypesEnum.BIG_INTEGER
-            bigDecimal, bigDecimal.makeNullable()-> KnownTypesEnum.BIG_DECIMAL
+            bigDecimal, bigDecimal.makeNullable() -> KnownTypesEnum.BIG_DECIMAL
             boolean, nullableBoolean -> KnownTypesEnum.BOOLEAN
             binary, binary.makeNullable() -> KnownTypesEnum.BINARY
             uuid, uuid.makeNullable() -> KnownTypesEnum.UUID

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/extension/JsonKoraExtension.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/extension/JsonKoraExtension.kt
@@ -61,6 +61,7 @@ class JsonKoraExtension(
                 writerTypeMetaParser.parse(possibleJsonClassDeclaration)
                 return { generateWriter(resolver, possibleJsonClassDeclaration) }
             } catch (e: ProcessingErrorException) {
+                e.message?.let { kspLogger.warn(it, null) }
                 return null
             }
         }
@@ -122,18 +123,18 @@ class JsonKoraExtension(
         return ExtensionResult.RequiresCompilingResult
     }
 
-    private fun generateWriter(resolver: Resolver, jsonClass: KSClassDeclaration): ExtensionResult {
-        val packageElement = jsonClass.packageName.asString()
-        val resultClassName = jsonClass.jsonWriterName()
+    private fun generateWriter(resolver: Resolver, declaration: KSClassDeclaration): ExtensionResult {
+        val packageElement = declaration.packageName.asString()
+        val resultClassName = declaration.jsonWriterName()
         val resultDeclaration = resolver.getClassDeclarationByName("$packageElement.$resultClassName")
         if (resultDeclaration != null) {
             return ExtensionResult.fromConstructor(findDefaultConstructor(resultDeclaration), resultDeclaration)
         }
-        if (jsonClass.isAnnotationPresent(JsonTypes.json) || jsonClass.isAnnotationPresent(JsonTypes.jsonWriterAnnotation)) {
+        if (declaration.isAnnotationPresent(JsonTypes.json) || declaration.isAnnotationPresent(JsonTypes.jsonWriterAnnotation)) {
             // annotation processor will handle that
             return ExtensionResult.RequiresCompilingResult
         }
-        processor.generateWriter(jsonClass)
+        processor.generateWriter(declaration)
         return ExtensionResult.RequiresCompilingResult
     }
 

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/JsonClassWriterMeta.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/JsonClassWriterMeta.kt
@@ -4,6 +4,32 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSName
 import com.google.devtools.ksp.symbol.KSType
 
-data class JsonClassWriterMeta(val classDeclaration: KSClassDeclaration, val fields: List<FieldMeta>) {
-    data class FieldMeta(val fieldSimpleName: KSName, val jsonName: String, val type: KSType, val typeMeta: WriterFieldType?, val writer: KSType?, val accessor: String)
+data class JsonClassWriterMeta(val type: KSClassDeclaration, val fields: List<FieldMeta>) {
+
+    enum class IncludeType {
+        ALWAYS, NON_NULL, NON_EMPTY;
+
+        companion object {
+            private val types = IncludeType.values()
+
+            fun tryParse(name: String): IncludeType? {
+                for (includeType in IncludeType.Companion.types) {
+                    if (includeType.name == name) {
+                        return includeType
+                    }
+                }
+                return null
+            }
+        }
+    }
+
+    data class FieldMeta(
+        val fieldSimpleName: KSName,
+        val jsonName: String,
+        val type: KSType,
+        val typeMeta: WriterFieldType?,
+        val writer: KSType?,
+        val accessor: String,
+        val includeType: IncludeType
+    )
 }

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/JsonWriterGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/JsonWriterGenerator.kt
@@ -50,10 +50,10 @@ class JsonWriterGenerator(private val resolver: Resolver) {
         }
         functionBody.addStatement("_gen.writeStartObject(_object)")
 
-        val discriminatorField = declaration.discriminatorField(resolver)
+        val discriminatorField = declaration.discriminatorField()
         if (discriminatorField != null) {
             if (meta.fields.none { it.jsonName == discriminatorField }) {
-                val discriminatorValue = meta.classDeclaration.discriminatorValues().first()
+                val discriminatorValue = meta.type.discriminatorValues().first()
                 functionBody.addStatement("_gen.writeFieldName(%S)", discriminatorField)
                 functionBody.addStatement("_gen.writeString(%S)", discriminatorValue)
             }

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/JsonWriterGenerator.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/JsonWriterGenerator.kt
@@ -12,25 +12,26 @@ import ru.tinkoff.kora.json.ksp.KnownType.KnownTypesEnum.*
 import ru.tinkoff.kora.json.ksp.discriminatorField
 import ru.tinkoff.kora.json.ksp.discriminatorValues
 import ru.tinkoff.kora.json.ksp.jsonWriterName
+import ru.tinkoff.kora.ksp.common.CommonClassNames
+import ru.tinkoff.kora.ksp.common.CommonClassNames.isCollection
+import ru.tinkoff.kora.ksp.common.CommonClassNames.isMap
 import ru.tinkoff.kora.ksp.common.KotlinPoetUtils.controlFlow
 import ru.tinkoff.kora.ksp.common.KspCommonUtils.generated
 import ru.tinkoff.kora.ksp.common.KspCommonUtils.toTypeName
 
-class JsonWriterGenerator(
-    private val resolver: Resolver
-) {
+class JsonWriterGenerator(private val resolver: Resolver) {
 
     fun generate(meta: JsonClassWriterMeta): TypeSpec {
-        val jsonClassDeclaration = meta.classDeclaration
-        val typeParameterResolver = jsonClassDeclaration.typeParameters.toTypeParameterResolver()
-        val typeName = meta.classDeclaration.toTypeName()
+        val declaration = meta.type
+        val typeParameterResolver = declaration.typeParameters.toTypeParameterResolver()
+        val typeName = declaration.toTypeName()
         val writerInterface = JsonTypes.jsonWriter.parameterizedBy(typeName)
-        val typeBuilder = TypeSpec.classBuilder(meta.classDeclaration.jsonWriterName())
+        val typeBuilder = TypeSpec.classBuilder(declaration.jsonWriterName())
             .generated(JsonWriterGenerator::class)
-        jsonClassDeclaration.containingFile?.let { typeBuilder.addOriginatingKSFile(it) }
+        declaration.containingFile?.let { typeBuilder.addOriginatingKSFile(it) }
         typeBuilder.addSuperinterface(writerInterface)
 
-        meta.classDeclaration.typeParameters.forEach {
+        declaration.typeParameters.forEach {
             typeBuilder.addTypeVariable(it.toTypeVariableName())
         }
 
@@ -49,7 +50,7 @@ class JsonWriterGenerator(
         }
         functionBody.addStatement("_gen.writeStartObject(_object)")
 
-        val discriminatorField = meta.classDeclaration.discriminatorField()
+        val discriminatorField = declaration.discriminatorField(resolver)
         if (discriminatorField != null) {
             if (meta.fields.none { it.jsonName == discriminatorField }) {
                 val discriminatorValue = meta.classDeclaration.discriminatorValues().first()
@@ -112,12 +113,47 @@ class JsonWriterGenerator(
     }
 
     private fun addWriteParam(function: CodeBlock.Builder, field: JsonClassWriterMeta.FieldMeta) {
-        function.controlFlow("_object.%N%L.let {", field.accessor, if (field.type.isMarkedNullable) "?" else "") {
+        val read = CodeBlock.builder()
+            .add("_gen.writeFieldName(%L)\n", jsonNameStaticName(field))
+        if (field.writer == null && field.typeMeta is WriterFieldType.KnownWriterFieldType) {
+            read.add(writeKnownType(field.typeMeta.knownType))
+        } else {
+            read.addStatement("%L.write(_gen, it)", writerFieldName(field))
+        }
+        if (!field.type.isMarkedNullable) {
+            function.controlFlow("_object.%N.let {", field.accessor) {
+                if (field.includeType == JsonClassWriterMeta.IncludeType.NON_EMPTY && (field.type.isCollection() || field.type.isMap())) {
+                    controlFlow("if (it.%M())", CommonClassNames.isNotEmpty) {
+                        add(read.build())
+                    }
+                } else {
+                    add(read.build())
+                }
+            }
+            return
+        }
+        if (field.includeType == JsonClassWriterMeta.IncludeType.NON_EMPTY && (field.type.isCollection() || field.type.isMap())) {
+            function.controlFlow("_object.%N?.let {", field.accessor) {
+                controlFlow("if (it.%M())", CommonClassNames.isNotEmpty) {
+                    add(read.build())
+                }
+            }
+        } else if (field.includeType != JsonClassWriterMeta.IncludeType.ALWAYS) {
+            function.controlFlow("_object.%N?.let {", field.accessor) {
+                add(read.build())
+            }
+        } else {
             function.add("_gen.writeFieldName(%L)\n", jsonNameStaticName(field))
-            if (field.writer == null && field.typeMeta is WriterFieldType.KnownWriterFieldType) {
-                function.add(writeKnownType(field.typeMeta.knownType))
-            } else {
-                function.addStatement("%L.write(_gen, it)", writerFieldName(field))
+            function.controlFlow("_object.%N.let {", field.accessor) {
+                if (field.writer == null && field.typeMeta is WriterFieldType.KnownWriterFieldType) {
+                    controlFlow("if (it == null)") {
+                        add("_gen.writeNull()")
+                        nextControlFlow("else")
+                        add(writeKnownType(field.typeMeta.knownType))
+                    }
+                } else {
+                    addStatement("%L.write(_gen, it)", writerFieldName(field))
+                }
             }
         }
     }

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/WriterFieldType.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/WriterFieldType.kt
@@ -1,10 +1,9 @@
 package ru.tinkoff.kora.json.ksp.writer
 
-import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeReference
 import ru.tinkoff.kora.json.ksp.KnownType
 
-sealed interface WriterFieldType{
-    data class KnownWriterFieldType(val knownType: KnownType.KnownTypesEnum, val markedNullable: Boolean): WriterFieldType
-    data class UnknownWriterFieldType(val type: KSTypeReference): WriterFieldType
+sealed interface WriterFieldType {
+    data class KnownWriterFieldType(val knownType: KnownType.KnownTypesEnum, val markedNullable: Boolean) : WriterFieldType
+    data class UnknownWriterFieldType(val type: KSTypeReference) : WriterFieldType
 }

--- a/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/WriterTypeMetaParser.kt
+++ b/json/json-symbol-processor/src/main/kotlin/ru/tinkoff/kora/json/ksp/writer/WriterTypeMetaParser.kt
@@ -2,10 +2,12 @@ package ru.tinkoff.kora.json.ksp.writer
 
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
+import com.squareup.kotlinpoet.ClassName
 import ru.tinkoff.kora.common.naming.NameConverter
 import ru.tinkoff.kora.json.ksp.JsonTypes
 import ru.tinkoff.kora.json.ksp.KnownType
 import ru.tinkoff.kora.json.ksp.findJsonField
+import ru.tinkoff.kora.ksp.common.AnnotationUtils.findAnnotation
 import ru.tinkoff.kora.ksp.common.AnnotationUtils.findValueNoDefault
 import ru.tinkoff.kora.ksp.common.AnnotationUtils.isAnnotationPresent
 import ru.tinkoff.kora.ksp.common.exception.ProcessingErrorException
@@ -13,33 +15,33 @@ import ru.tinkoff.kora.ksp.common.getNameConverter
 import ru.tinkoff.kora.ksp.common.isJavaRecord
 import ru.tinkoff.kora.ksp.common.parseAnnotationValue
 
-class WriterTypeMetaParser(resolver: Resolver) {
+class WriterTypeMetaParser(val resolver: Resolver) {
     private val knownTypes: KnownType = KnownType(resolver)
 
-    fun parse(jsonCLassDeclaration: KSClassDeclaration): JsonClassWriterMeta {
-        val fieldElements = parseFields(jsonCLassDeclaration)
+    fun parse(jsonClassDeclaration: KSClassDeclaration): JsonClassWriterMeta {
+        val fieldElements = parseFields(jsonClassDeclaration)
         val fieldMetas = mutableListOf<JsonClassWriterMeta.FieldMeta>()
         for (fieldElement in fieldElements) {
-            val fieldMeta = parseField(jsonCLassDeclaration, fieldElement)
+            val fieldMeta = parseField(jsonClassDeclaration, fieldElement)
             fieldMetas.add(fieldMeta)
         }
-        return JsonClassWriterMeta(jsonCLassDeclaration, fieldMetas)
+        return JsonClassWriterMeta(jsonClassDeclaration, fieldMetas)
     }
 
-    private fun parseFields(jsonCLassDeclaration: KSClassDeclaration): List<KSDeclaration> {
-        return if (jsonCLassDeclaration.isJavaRecord()) {
-            jsonCLassDeclaration.getAllFunctions()
+    private fun parseFields(jsonClassDeclaration: KSClassDeclaration): List<KSDeclaration> {
+        return if (jsonClassDeclaration.isJavaRecord()) {
+            jsonClassDeclaration.getAllFunctions()
                 .filter { f -> f.simpleName.asString() !in listOf("hashCode", "equals", "toString", "<init>") }
                 .filter { p -> !p.isAnnotationPresent(JsonTypes.jsonSkipAnnotation) }
                 .toList()
         } else {
-            jsonCLassDeclaration.getAllProperties()
+            jsonClassDeclaration.getAllProperties()
                 .filter { p -> !p.isAnnotationPresent(JsonTypes.jsonSkipAnnotation) }
                 .toList()
         }
     }
 
-    private fun parseField(jsonClass: KSClassDeclaration, field: KSDeclaration): JsonClassWriterMeta.FieldMeta {
+    private fun parseField(jsonClassDeclaration: KSClassDeclaration, field: KSDeclaration): JsonClassWriterMeta.FieldMeta {
         val jsonField = findJsonField(field)
         val type = if (field is KSFunctionDeclaration) {
             field.returnType!!
@@ -47,15 +49,22 @@ class WriterTypeMetaParser(resolver: Resolver) {
             (field as KSPropertyDeclaration).type
         }
         val resolvedType = type.resolve()
-        val fieldNameConverter = jsonClass.getNameConverter()
+        val fieldNameConverter = jsonClassDeclaration.getNameConverter()
         if (resolvedType.isError) {
-            throw ProcessingErrorException("Field %s.%s is ERROR".format(jsonClass, field.simpleName.asString()), field)
+            throw ProcessingErrorException("Field %s.%s is ERROR".format(jsonClassDeclaration, field.simpleName.asString()), field)
         }
         val jsonName = parseJsonName(field, jsonField, fieldNameConverter)
         val accessor = field.simpleName.asString()
         val writer = jsonField?.findValueNoDefault<KSType>("writer")
         val typeMeta = parseWriterFieldType(type, resolvedType)
-        return JsonClassWriterMeta.FieldMeta(field.simpleName, jsonName, type.resolve(), typeMeta, writer, accessor)
+
+        val includeType = ((field.findAnnotation(JsonTypes.jsonInclude)
+            ?: jsonClassDeclaration.findAnnotation(JsonTypes.jsonInclude))
+            ?.arguments?.filter { a -> (a.name?.getShortName() ?: "") == "value" }
+            ?.firstNotNullOfOrNull { arg -> JsonClassWriterMeta.IncludeType.tryParse(ClassName.bestGuess(arg.value.toString()).simpleName) }
+            ?: JsonClassWriterMeta.IncludeType.NON_NULL)
+
+        return JsonClassWriterMeta.FieldMeta(field.simpleName, jsonName, type.resolve(), typeMeta, writer, accessor, includeType)
     }
 
     private fun parseWriterFieldType(type: KSTypeReference, resolvedType: KSType): WriterFieldType {

--- a/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/GenericsTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/GenericsTest.kt
@@ -52,12 +52,36 @@ class GenericsTest : AbstractJsonSymbolProcessorTest() {
     }
 
     @Test
+    fun testGenericJsonWriterExtensionWithIncludeClassAlways() {
+        compile(
+            listOf(KoraAppProcessorProvider()),
+            """
+            import ru.tinkoff.kora.json.common.annotation.JsonInclude
+            
+            @JsonInclude(JsonInclude.IncludeType.ALWAYS)
+            data class TestClass <T> (val value: T?, val values: List<T>?)             
+            """.trimIndent(),
+            """
+                @KoraApp
+                interface TestApp : ru.tinkoff.kora.json.common.JsonCommonModule {
+                  @Root
+                  fun root(w1: ru.tinkoff.kora.json.common.JsonWriter<TestClass<String?>>) = ""
+                }
+            """.trimIndent()
+        )
+        val graph = loadClass("TestAppGraph").toGraph()
+        val writer = graph.findAllByType(writerClass("TestClass")) as List<JsonWriter<Any?>>
+
+        writer[0].assertWrite(new("TestClass", null, null), "{\"value\":null,\"values\":null}")
+    }
+
+    @Test
     fun testGenericJsonReaderExtensionWithAnnotation() {
         compile(
             listOf(KoraAppProcessorProvider(), JsonSymbolProcessorProvider()),
             """
             @ru.tinkoff.kora.json.common.annotation.Json
-            data class TestClass <T> (val value:T)             
+            data class TestClass <T> (val value: T)             
             """.trimIndent(),
             """
                 @KoraApp

--- a/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/JsonIncludeTest.kt
+++ b/json/json-symbol-processor/src/test/kotlin/ru/tinkoff/kora/json/ksp/JsonIncludeTest.kt
@@ -1,0 +1,95 @@
+package ru.tinkoff.kora.json.ksp
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonParser
+import org.junit.jupiter.api.Test
+import ru.tinkoff.kora.json.common.ListJsonReader
+import ru.tinkoff.kora.json.common.ListJsonWriter
+
+class JsonIncludeTest : AbstractJsonSymbolProcessorTest() {
+    @Test
+    fun testIncludeAlways() {
+        compile("""
+            import ru.tinkoff.kora.json.common.annotation.JsonInclude
+                            
+            @JsonInclude(JsonInclude.IncludeType.ALWAYS)
+            @Json
+            data class TestRecord(val value: Int?)
+            """
+            .trimIndent()
+        )
+        compileResult.assertSuccess()
+        val mapper = mapper("TestRecord")
+        mapper.assertWrite(new("TestRecord", 42), "{\"value\":42}")
+        mapper.assertWrite(new("TestRecord", null), "{\"value\":null}")
+    }
+
+    @Test
+    fun testIncludeNonNull() {
+        compile("""
+            import ru.tinkoff.kora.json.common.annotation.JsonInclude;
+                            
+            @JsonInclude(JsonInclude.IncludeType.NON_NULL)
+            @Json
+            data class TestRecord(val value: Int?)
+            """
+            .trimIndent()
+        )
+        compileResult.assertSuccess()
+        val mapper = mapper("TestRecord")
+        mapper.assertWrite(new("TestRecord", 42), "{\"value\":42}")
+        mapper.assertWrite(new("TestRecord", null), "{}")
+    }
+
+    @Test
+    fun testIncludeNonEmpty() {
+        compile("""
+            import ru.tinkoff.kora.json.common.annotation.JsonInclude;
+                            
+            @JsonInclude(JsonInclude.IncludeType.NON_EMPTY)
+            @Json
+            data class TestRecord(val value: List<Int>?)
+            
+            """
+            .trimIndent()
+        )
+        compileResult.assertSuccess()
+        val mapper = mapper("TestRecord", listOf(ListJsonReader<Int> { obj: JsonParser -> obj.intValue }), listOf(ListJsonWriter<Int> { obj: JsonGenerator, v: Int? -> obj.writeNumber(v!!) }))
+        mapper.assertWrite(new("TestRecord", listOf(42)), "{\"value\":[42]}")
+        mapper.assertWrite(new("TestRecord", listOf<Any>()), "{}")
+        mapper.assertWrite(new("TestRecord", null), "{}")
+    }
+
+    @Test
+    fun testFieldIncludeAlways() {
+        compile("""
+            import ru.tinkoff.kora.json.common.annotation.JsonInclude;
+                            
+            @Json
+            data class TestRecord(val name: String?, @JsonInclude(JsonInclude.IncludeType.ALWAYS) val value: Int?)
+            """
+            .trimIndent()
+        )
+        compileResult.assertSuccess()
+        val mapper = mapper("TestRecord")
+        mapper.assertWrite(new("TestRecord", "test", 42), "{\"name\":\"test\",\"value\":42}")
+        mapper.assertWrite(new("TestRecord", null, null), "{\"value\":null}")
+    }
+
+    @Test
+    fun testFieldIncludeNonEmpty() {
+        compile("""
+            import ru.tinkoff.kora.json.common.annotation.JsonInclude;
+                            
+            @Json
+            data class TestRecord(@JsonInclude(JsonInclude.IncludeType.NON_EMPTY) val value: List<Int>?)
+            """
+            .trimIndent()
+        )
+        compileResult.assertSuccess()
+        val mapper = mapper("TestRecord", listOf(ListJsonReader<Int> { obj: JsonParser -> obj.intValue }), listOf(ListJsonWriter<Int> { obj: JsonGenerator, v: Int? -> obj.writeNumber(v!!) }))
+        mapper.assertWrite(new("TestRecord", listOf(42)), "{\"value\":[42]}")
+        mapper.assertWrite(new("TestRecord", listOf<Any>()), "{}")
+        mapper.assertWrite(new("TestRecord", null), "{}")
+    }
+}

--- a/symbol-processor-common/src/main/kotlin/ru/tinkoff/kora/ksp/common/CommonClassNames.kt
+++ b/symbol-processor-common/src/main/kotlin/ru/tinkoff/kora/ksp/common/CommonClassNames.kt
@@ -1,14 +1,14 @@
 package ru.tinkoff.kora.ksp.common
 
+import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeReference
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.ksp.toClassName
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CompletionStage
-import java.util.concurrent.Future
+import java.util.*
+import java.util.concurrent.*
 
 object CommonClassNames {
     val publisher = ClassName("org.reactivestreams", "Publisher")
@@ -52,22 +52,82 @@ object CommonClassNames {
     val config = ClassName("com.typesafe.config", "Config")
     val configValueExtractor = ClassName("ru.tinkoff.kora.config.common.extractor", "ConfigValueExtractor")
 
+    val isNotEmpty = MemberName("kotlin.collections", "isNotEmpty")
+
+    fun KSType.isList(): Boolean {
+        val className = if (this.declaration is KSClassDeclaration) this.toClassName().canonicalName else this.toString()
+        return className == List::class.qualifiedName
+            || className == MutableList::class.qualifiedName
+            || className == ArrayList::class.qualifiedName
+            || className == LinkedList::class.qualifiedName
+    }
+
+    fun KSType.isSet(): Boolean {
+        val className = if (this.declaration is KSClassDeclaration) this.toClassName().canonicalName else this.toString()
+        return className == Set::class.qualifiedName
+            || className == MutableSet::class.qualifiedName
+            || className == HashSet::class.qualifiedName
+            || className == TreeSet::class.qualifiedName
+            || className == SortedSet::class.qualifiedName
+            || className == LinkedHashSet::class.qualifiedName
+            || className == CopyOnWriteArraySet::class.qualifiedName
+            || className == ConcurrentSkipListSet::class.qualifiedName
+    }
+
+    fun KSType.isQueue(): Boolean {
+        val className = if (this.declaration is KSClassDeclaration) this.toClassName().canonicalName else this.toString()
+        return className == Queue::class.qualifiedName
+            || className == Deque::class.qualifiedName
+    }
+
+    fun KSType.isCollection(): Boolean {
+        val className = if (this.declaration is KSClassDeclaration) this.toClassName().canonicalName else this.toString()
+        return className == Collection::class.qualifiedName
+            || className == MutableCollection::class.qualifiedName
+            || isList()
+            || isSet()
+            || isQueue()
+    }
+
+    fun KSType.isMap(): Boolean {
+        val className = if (this.declaration is KSClassDeclaration) this.toClassName().canonicalName else this.toString()
+        return className == Map::class.qualifiedName
+            || className == MutableMap::class.qualifiedName
+            || className == HashMap::class.qualifiedName
+            || className == TreeMap::class.qualifiedName
+            || className == ConcurrentMap::class.qualifiedName
+            || className == ConcurrentHashMap::class.qualifiedName
+            || className == LinkedHashMap::class.qualifiedName
+            || className == SortedMap::class.qualifiedName
+            || className == NavigableMap::class.qualifiedName
+            || className == ConcurrentSkipListMap::class.qualifiedName
+            || className == IdentityHashMap::class.qualifiedName
+            || className == WeakHashMap::class.qualifiedName
+            || className == EnumMap::class.qualifiedName
+    }
+
+    fun KSType.isIterable(): Boolean {
+        val className = if (this.declaration is KSClassDeclaration) this.toClassName().canonicalName else this.toString()
+        return className == Iterable::class.qualifiedName
+            || className == MutableIterable::class.qualifiedName
+            || isCollection()
+            || isMap()
+    }
 
     fun KSType.isMono() = this.toClassName().canonicalName == mono.canonicalName
     fun KSType.isFlux() = this.toClassName().canonicalName == flux.canonicalName
     fun KSType.isFlow() = this.toClassName().canonicalName == flow.canonicalName
     fun KSType.isPublisher() = this.toClassName().canonicalName == publisher.canonicalName
-    fun KSType.isList() = this.toClassName().canonicalName == list.canonicalName
 
     fun KSType.isFuture(): Boolean {
         val className = this.toClassName()
-        return className.canonicalName == Future::class.java.canonicalName
-            || className.canonicalName == CompletionStage::class.java.canonicalName
-            || className.canonicalName == CompletableFuture::class.java.canonicalName
+        return className.canonicalName == Future::class.qualifiedName
+            || className.canonicalName == CompletionStage::class.qualifiedName
+            || className.canonicalName == CompletableFuture::class.qualifiedName
     }
 
     fun KSTypeReference.isVoid(): Boolean {
         val typeAsStr = resolve().toClassName().canonicalName
-        return Void::class.java.canonicalName == typeAsStr || "void" == typeAsStr || Unit::class.java.canonicalName == typeAsStr
+        return Void::class.qualifiedName == typeAsStr || "void" == typeAsStr || Unit::class.qualifiedName == typeAsStr
     }
 }


### PR DESCRIPTION
Adds `@JsonInclude` with `ALWAYS`, `NOT_NULL`, `NOT_EMPTY` options to apply when choosing if variable should be serialized to JSON