### PR TITLE
Repository inheritance scan

### DIFF
--- a/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/extension/RepositoryKoraExtension.java
+++ b/database/database-annotation-processor/src/main/java/ru/tinkoff/kora/database/annotation/processor/extension/RepositoryKoraExtension.java
@@ -1,6 +1,7 @@
 package ru.tinkoff.kora.database.annotation.processor.extension;
 
 import ru.tinkoff.kora.annotation.processor.common.CommonUtils;
+import ru.tinkoff.kora.annotation.processor.common.ProcessingErrorException;
 import ru.tinkoff.kora.database.annotation.processor.DbUtils;
 import ru.tinkoff.kora.kora.app.annotation.processor.extension.ExtensionResult;
 import ru.tinkoff.kora.kora.app.annotation.processor.extension.KoraExtension;
@@ -10,10 +11,12 @@ import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
+import java.util.Objects;
 
 public class RepositoryKoraExtension implements KoraExtension {
     private final Elements elements;
@@ -33,10 +36,45 @@ public class RepositoryKoraExtension implements KoraExtension {
         if (element.getKind() != ElementKind.INTERFACE && (element.getKind() != ElementKind.CLASS || !element.getModifiers().contains(Modifier.ABSTRACT))) {
             return null;
         }
-        if (CommonUtils.findDirectAnnotation(element, DbUtils.REPOSITORY_ANNOTATION) == null) {
-            return null;
+
+        final TypeElement typeElement;
+        if (CommonUtils.findDirectAnnotation(element, DbUtils.REPOSITORY_ANNOTATION) != null) {
+            typeElement = (TypeElement) this.types.asElement(typeMirror);
+        } else {
+            var candidates = roundEnvironment.getRootElements().stream()
+                .filter(candidate -> candidate instanceof TypeElement)
+                .map(candidate -> {
+                    if (types.isAssignable(candidate.asType(), typeMirror)
+                        && !types.isSameType(candidate.asType(), typeMirror)) {
+                        if (CommonUtils.findDirectAnnotation(candidate, DbUtils.REPOSITORY_ANNOTATION) != null) {
+                            return ((TypeElement) candidate);
+                        } else {
+                            return types.directSupertypes(candidate.asType()).stream()
+                                .filter(parentType -> parentType instanceof DeclaredType)
+                                .map(parentType -> ((DeclaredType) parentType))
+                                .filter(parentType -> CommonUtils.findDirectAnnotation(parentType.asElement(), DbUtils.REPOSITORY_ANNOTATION) != null)
+                                .findFirst()
+                                .map(parentType -> ((TypeElement) parentType.asElement()))
+                                .orElse(null);
+                        }
+                    } else {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .toList();
+
+            if (candidates.isEmpty()) {
+                return null;
+            }
+
+            if (candidates.size() > 1) {
+                throw new ProcessingErrorException("Found '%s' suitable candidates for: %s".formatted(candidates.size(), element), element);
+            } else {
+                typeElement = candidates.get(0);
+            }
         }
-        var typeElement = (TypeElement) this.types.asElement(typeMirror);
+
         var packageElement = this.elements.getPackageOf(typeElement);
         var repositoryName = CommonUtils.getOuterClassesAsPrefix(typeElement) + typeElement.getSimpleName().toString() + "_Impl";
         var packageName = packageElement.getQualifiedName();

--- a/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/jdbc/JdbcParametersTest.java
+++ b/database/database-annotation-processor/src/test/java/ru/tinkoff/kora/database/common/annotation/processor/jdbc/JdbcParametersTest.java
@@ -10,6 +10,7 @@ import ru.tinkoff.kora.database.common.annotation.processor.entity.TestEntityJav
 import ru.tinkoff.kora.database.common.annotation.processor.entity.TestEntityRecord;
 import ru.tinkoff.kora.database.common.annotation.processor.jdbc.repository.AllowedParametersRepository;
 import ru.tinkoff.kora.database.jdbc.JdbcConnectionFactory;
+import ru.tinkoff.kora.database.jdbc.JdbcDatabaseConfig;
 import ru.tinkoff.kora.database.jdbc.mapper.parameter.JdbcParameterColumnMapper;
 import ru.tinkoff.kora.json.common.annotation.Json;
 
@@ -105,6 +106,32 @@ public class JdbcParametersTest extends AbstractJdbcRepositoryTest {
                        
                 @Query("INSERT INTO test(test) VALUES ('test')")
                 void testConnection(Connection connection);
+            }
+            """);
+
+        repository.invoke("testConnection", executor.mockConnection);
+
+        verify(executor.mockConnection).prepareStatement("INSERT INTO test(test) VALUES ('test')");
+        verify(executor.preparedStatement).execute();
+    }
+
+    @Test
+    public void testAbstractClassRepository() throws SQLException {
+        var config = new JdbcDatabaseConfig("1", "2", "3", "4",
+            null, null, null, null, null, null, null, null, null);
+        var repository = compileForArgs(List.of(config, executor), """
+            import ru.tinkoff.kora.database.jdbc.JdbcDatabaseConfig;
+            @Repository
+            public abstract class TestRepository implements JdbcRepository {
+            
+                private final JdbcDatabaseConfig config;
+                
+                public TestRepository(JdbcDatabaseConfig config) {
+                    this.config = config;
+                }
+                       
+                @Query("INSERT INTO test(test) VALUES ('test')")
+                abstract void testConnection(Connection connection);
             }
             """);
 

--- a/database/database-symbol-processor/src/test/kotlin/ru/tinkoff/kora/database/symbol/processor/AbstractRepositoryTest.kt
+++ b/database/database-symbol-processor/src/test/kotlin/ru/tinkoff/kora/database/symbol/processor/AbstractRepositoryTest.kt
@@ -56,7 +56,6 @@ abstract class AbstractRepositoryTest : AbstractSymbolProcessorTest() {
             throw compileResult.compilationException()
         }
 
-        val repositoryClass = compileResult.loadClass("\$TestRepository_Impl")
         val realArgs = arrayOfNulls<Any>(arguments.size + 1)
         realArgs[0] = connectionFactory
         System.arraycopy(arguments.toTypedArray(), 0, realArgs, 1, arguments.size)
@@ -65,7 +64,20 @@ abstract class AbstractRepositoryTest : AbstractSymbolProcessorTest() {
                 realArgs[i] = arg.invoke()
             }
         }
+
+        val repositoryClass = compileResult.loadClass("\$TestRepository_Impl")
         val repository = repositoryClass.constructors[0].newInstance(*realArgs)
+        return TestRepository(repositoryClass.kotlin, repository)
+    }
+
+    protected fun compileForArgs(arguments: Array<Any?>, @Language("kotlin") vararg sources: String): TestRepository {
+        val compileResult = compile(listOf(RepositorySymbolProcessorProvider()), *sources)
+        if (compileResult.isFailed()) {
+            throw compileResult.compilationException()
+        }
+
+        val repositoryClass = compileResult.loadClass("\$TestRepository_Impl")
+        val repository = repositoryClass.constructors[0].newInstance(*arguments)
         return TestRepository(repositoryClass.kotlin, repository)
     }
 }


### PR DESCRIPTION
Features:
- database repository inheritance scan (closes #167)

```java
interface FooRepository { ... }

@Repository
abstract class AbstractFooRepository( ... ) : FooRepository, JdbcRepository { ... }

@Component
class FooService(val repo: FooRepository)
```